### PR TITLE
[volume-7] 트랜잭션 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ docker-compose -f ./docker/infra-compose.yml up
 docker-compose -f ./docker/monitoring-compose.yml up
 ```
 
+### About Multi-Module Project
+본 프로젝트는 멀티 모듈 프로젝트로 구성되어 있습니다. 각 모듈의 위계 및 역할을 분명히 하고, 아래와 같은 규칙을 적용합니다.
+
+apps : 각 모듈은 실행가능한 SpringBootApplication 을 의미합니다.
+modules : 특정 구현이나 도메인에 의존적이지 않고, reusable 한 configuration 을 원칙으로 합니다.
+supports : logging, monitoring 과 같이 부가적인 기능을 지원하는 add-on 모듈입니다.
+Root
+├── apps ( spring-applications )
+│   └── 📦 commerce-api
+│   └── 📦 pg-simulator
+├── modules ( reusable-configurations )
+│   ├── 📦 jpa
+│   └── 📦 redis
+└── supports ( add-ons )
+├── 📦 jackson
+├── 📦 logging
+└── 📦 monitoring
+
 ### 개발환경
 - **Language**: Java 21
 - **Framework**: Spring Boot 3.4.4

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.TimeZone;
 
@@ -17,6 +18,7 @@ import java.util.TimeZone;
                 description = "쇼핑·주문·결제 기능을 제공하는 이커머스 플랫폼 API"
         )
 )
+@EnableAsync
 @EnableRetry
 @EnableFeignClients
 @ConfigurationPropertiesScan

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,7 +1,9 @@
 package com.loopers.application.like;
 
+import com.loopers.domain.event.LikeEventPublisher;
+import com.loopers.domain.event.dto.LikeAddEvent;
+import com.loopers.domain.event.dto.LikeDeleteEvent;
 import com.loopers.domain.like.LikeService;
-import com.loopers.domain.product.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,12 +12,12 @@ import org.springframework.stereotype.Component;
 public class LikeFacade {
 
     private final LikeService likeService;
-    private final ProductService productService;
+    private final LikeEventPublisher likeEventPublisher;
 
     public LikeInfo.Main add(LikeCommand.Main command) {
         boolean isNew = likeService.add(command.toDomain());
         if (isNew) {
-            productService.increaseLike(command.getProductId());
+            likeEventPublisher.publish(LikeAddEvent.of(command.getProductId()));
         }
         return LikeInfo.Main.from(command.getProductId(), true);
     }
@@ -23,7 +25,7 @@ public class LikeFacade {
     public LikeInfo.Main delete(LikeCommand.Main command) {
         boolean isNew = likeService.delete(command.toDomain());
         if (isNew) {
-            productService.decreaseLike(command.getProductId());
+            likeEventPublisher.publish(LikeDeleteEvent.of(command.getProductId()));
         }
         return LikeInfo.Main.from(command.getProductId(), false);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -17,7 +17,7 @@ public class LikeFacade {
     public LikeInfo.Main add(LikeCommand.Main command) {
         boolean isNew = likeService.add(command.toDomain());
         if (isNew) {
-            likeEventPublisher.publish(LikeAddEvent.of(command.getProductId()));
+            likeEventPublisher.publish(LikeAddEvent.of(command.getProductId(), command.getUserId()));
         }
         return LikeInfo.Main.from(command.getProductId(), true);
     }
@@ -25,7 +25,7 @@ public class LikeFacade {
     public LikeInfo.Main delete(LikeCommand.Main command) {
         boolean isNew = likeService.delete(command.toDomain());
         if (isNew) {
-            likeEventPublisher.publish(LikeDeleteEvent.of(command.getProductId()));
+            likeEventPublisher.publish(LikeDeleteEvent.of(command.getProductId(), command.getUserId()));
         }
         return LikeInfo.Main.from(command.getProductId(), false);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/CouponUseService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/CouponUseService.java
@@ -15,16 +15,17 @@ public class CouponUseService {
     private final CouponService couponService;
     private final UserCouponService userCouponService;
 
-    @Transactional
-    public int use(Long userCouponId, Long userId, int orderAmount) {
+    @Transactional(readOnly = true)
+    public int calculateDiscountAmount(Long userCouponId, Long userId, int orderAmount) {
         UserCoupon userCoupon = userCouponService.getDetail(userCouponId, userId);
-
         Coupon coupon = couponService.getDetail(userCoupon.getCouponId());
         couponService.validateAmount(coupon, orderAmount);
-        int discountAmount = couponService.calculateDiscountAmount(coupon, orderAmount);
 
+        return couponService.calculateDiscountAmount(coupon, orderAmount);
+    }
+
+    @Transactional
+    public void use(Long userCouponId, Long userId) {
         userCouponService.use(userCouponId, userId);
-
-        return discountAmount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -31,6 +31,7 @@ public class OrderFacade {
         } catch (Exception e) {
             log.error("주문 처리 중 예외 발생: {}", e.getLocalizedMessage());
             order.markOrderFailed();
+            return OrderInfo.Main.from(order);
         }
 
         // 주문 완료 이벤트 발행

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -4,6 +4,8 @@ import com.loopers.application.order.dto.OrderCommand;
 import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
+import com.loopers.domain.event.dto.OrderCreatedEvent;
+import com.loopers.domain.event.OrderEventPublisher;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,17 +19,24 @@ public class OrderFacade {
 
     private final OrderService orderService;
     private final OrderValidationService orderValidateService;
+    private final OrderEventPublisher orderEventPublisher;
 
     @Transactional
     public OrderInfo.Main create(OrderCommand.Create command) {
         Order order = orderService.create(command.toDomain());
 
         try {
+            // 주문 검증
             orderValidateService.validate(command, order);
-        } catch (Exception ex) {
-            log.error("주문 처리 중 예외 발생: {}", ex.getLocalizedMessage());
+        } catch (Exception e) {
+            log.error("주문 처리 중 예외 발생: {}", e.getLocalizedMessage());
             order.markOrderFailed();
         }
+
+        // 주문 완료 이벤트 발행
+        orderEventPublisher.publish(
+                OrderCreatedEvent.of(order.getId(), order.getUserId(), order.getPaymentAmount(), command.getMethod(), command.getCardType(), command.getCardNo())
+        );
 
         return OrderInfo.Main.from(order);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import jakarta.transaction.Transactional;
@@ -14,14 +16,14 @@ import org.springframework.stereotype.Component;
 public class OrderFacade {
 
     private final OrderService orderService;
-    private final OrderProcessor orderProcessor;
+    private final OrderValidationService orderValidateService;
 
     @Transactional
     public OrderInfo.Main create(OrderCommand.Create command) {
         Order order = orderService.create(command.toDomain());
 
         try {
-            orderProcessor.process(command, order);
+            orderValidateService.validate(command, order);
         } catch (Exception ex) {
             log.error("주문 처리 중 예외 발생: {}", ex.getLocalizedMessage());
             order.markOrderFailed();

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
@@ -1,19 +1,23 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.dto.OrderCommand;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class OrderProcessor {
+public class OrderValidationService {
 
     private final CouponUseService couponUseService;
     private final StockService stockService;
-    private final PointProcessor pointProcessor;
+    private final PointUseService pointUseService;
 
-    public void process(OrderCommand.Create command, Order order) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void validate(OrderCommand.Create command, Order order) {
         // 쿠폰 조회 및 사용
         int discountAmount = 0;
         if (command.getUserCouponId() != null) {
@@ -27,7 +31,7 @@ public class OrderProcessor {
         }
 
         // 포인트 조회 및 차감
-        pointProcessor.useWithLock(command.getUserId(), command.getPoint(), order.getId());
+        pointUseService.useWithLock(command.getUserId(), command.getPoint(), order.getId());
         order.setPointAmount(command.getPoint());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/PointUseService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/PointUseService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class PointProcessor {
+public class PointUseService {
 
     private final PointService pointService;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
@@ -3,6 +3,8 @@ package com.loopers.application.order.dto;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.dto.CardType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +24,9 @@ public class OrderCommand {
         private List<Item> items;
         private Long userCouponId;
         private int point;
+        private PaymentMethod method;
+        private CardType cardType;
+        private String cardNo;
 
         public Order toDomain() {
             List<OrderItem> orderItems = items.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderInfo.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
@@ -1,0 +1,8 @@
+package com.loopers.application.payment;
+
+import java.util.Map;
+
+public interface PaymentAlertSender {
+
+    void sendFail(Map<String, Object> params, Exception e);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
@@ -4,5 +4,5 @@ import java.util.Map;
 
 public interface PaymentAlertSender {
 
-    void sendFail(Map<String, Object> params, Exception e);
+    void sendFail(Map<String, Object> params, String message);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,31 +1,36 @@
 package com.loopers.application.payment;
 
 import com.loopers.application.order.ExternalOrderSender;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.Payment;
-import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentFacade {
 
-    private final OrderService orderService;
-    private final PaymentService paymentService;
-    private final PaymentProcessor paymentProcessor;
-    private final PaymentGateway paymentGateway;
+    private final PaymentGatewayService paymentGatewayService;
     private final PaymentRestoreService paymentRestoreService;
     private final PaymentRetryService paymentRetryService;
     private final ExternalOrderSender externalOrderSender;
+    private final PaymentAlertSender paymentAlertSender;
+    private final OrderService orderService;
+    private final PaymentService paymentService;
 
     @Transactional
     public PaymentInfo.Main payment(PaymentCommand.Create command) {
@@ -35,19 +40,24 @@ public class PaymentFacade {
         order.markWaitingPayment();
 
         // 결제 생성
-        Payment payment = paymentService.create(command.getUserId(), order.getId(), order.getPaymentAmount(), PaymentMethod.CARD);
+        Payment payment = paymentService.create(command.getUserId(), order.getId(), order.getPaymentAmount(), command.getMethod());
 
         // PG 결제 요청
-        paymentProcessor.process(command.toRequest(order, payment));
+        PaymentResponse response = paymentGatewayService.requestPayment(command.toRequest(order, payment));
+        if (response.getStatus() == PaymentResponseResult.SUCCESS) {
+            payment.setPaymentPending(response.getTransactionKey());
+        }
 
         return PaymentInfo.Main.from(payment);
     }
 
-    public PaymentInfo.Callback paymentCallback(PaymentCommand.Modify command) {
+    @Transactional
+    public void paymentCallback(PaymentCommand.Callback command) {
         try {
-            PaymentResponse response = paymentGateway.getTransaction(command.getTransactionKey());
-            if (response.getStatus().equals("FAIL")) {
-                return PaymentInfo.Callback.from("FAIL", response.getReason());
+            // PG 결제 조회
+            PaymentInfo.Callback info = paymentGatewayService.getTransaction(command.getTransactionKey());
+            if (info.getResult() == PaymentResponseResult.FAIL) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "결제 결과가 일치하지 않습니다.");
             }
 
             Payment payment = paymentService.getDetailByKeyWithLock(command.getTransactionKey());
@@ -56,19 +66,23 @@ public class PaymentFacade {
             Order order = orderService.getDetailWithLock(payment.getOrderId());
             orderService.checkWaitingOrder(order);
 
-            if (command.getStatus().equals("SUCCESS")) {
-                payment.setPaymentSuccess(command.getReason());
-                order.markPaid();
-                externalOrderSender.send(order);
-            } else {
-                payment.setPaymentFailed(command.getReason());
-                order.markPaymentFailed();
-                paymentRestoreService.restore(order);
+            switch (command.getResult()) {
+                case SUCCESS -> {
+                    payment.setPaymentSuccess(command.getReason());
+                    order.markPaid();
+                    externalOrderSender.send(order);
+                }
+                case FAIL -> {
+                    payment.setPaymentFailed(command.getReason());
+                    order.markPaymentFailed();
+                    paymentRestoreService.restore(order);
+                }
             }
-
-            return PaymentInfo.Callback.from("SUCCESS", null);
         } catch (Exception e) {
-            return PaymentInfo.Callback.from("FAIL", e.getLocalizedMessage());
+            log.error("PG 콜백 처리 실패: command={}", command, e);
+
+            // 알림 전송
+            paymentAlertSender.sendFail(Map.of("transactionKey", command.getTransactionKey()), e);
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
@@ -54,7 +54,7 @@ public class PaymentGatewayService {
 
     public PaymentInfo.Callback getTransaction(String transactionKey) {
         PaymentResponse response = paymentGateway.getTransaction(transactionKey);
-        if (response.getStatus().equals(PaymentResponseResult.FAIL)) {
+        if (response.getStatus() == PaymentResponseResult.FAIL) {
             return PaymentInfo.Callback.from(PaymentResponseResult.FAIL, response.getReason());
         }
         return PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null);

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
@@ -1,12 +1,14 @@
-package com.loopers.domain.payment;
+package com.loopers.application.payment;
 
-import com.loopers.application.payment.PaymentGateway;
-import com.loopers.application.payment.PaymentProcessor;
-import com.loopers.application.payment.PaymentRestoreService;
+import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CardPaymentProcessor implements PaymentProcessor {
+public class PaymentGatewayService {
 
     private final PaymentGateway paymentGateway;
     private final PaymentService paymentService;
@@ -32,20 +34,12 @@ public class CardPaymentProcessor implements PaymentProcessor {
     @CircuitBreaker(name = "pgCircuit", fallbackMethod = "fallback")
     @Retry(name = "pgRetry", fallbackMethod = "fallback")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Override
-    public PaymentResponse process(PaymentRequest request) {
-        Payment payment = paymentService.getDetail(request.getPaymentId());
-
-        // 결제 API 호출
-        PaymentResponse response = paymentGateway.requestPayment(request, callbackUrl);
-        if (response.getStatus().equals("SUCCESS")) {
-            payment.setPaymentPending(response.getTransactionKey());
-        }
-
-        return response;
+    public PaymentResponse requestPayment(PaymentRequest request) {
+        return paymentGateway.requestPayment(request, callbackUrl);
     }
 
-    public void fallback(PaymentRequest request, Throwable throwable) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PaymentResponse fallback(PaymentRequest request, Throwable throwable) {
         Payment payment = paymentService.getDetail(request.getPaymentId());
         Order order = orderService.getDetail(payment.getOrderId());
 
@@ -54,5 +48,15 @@ public class CardPaymentProcessor implements PaymentProcessor {
         paymentRestoreService.restore(order);
 
         log.error("결제 요청 실패 fallback: orderId={} paymentId={} message={}", order.getId(), payment.getId(), throwable.getLocalizedMessage());
+
+        return PaymentResponse.fail("결제에 실패했습니다." + throwable.getLocalizedMessage());
+    }
+
+    public PaymentInfo.Callback getTransaction(String transactionKey) {
+        PaymentResponse response = paymentGateway.getTransaction(transactionKey);
+        if (response.getStatus().equals(PaymentResponseResult.FAIL)) {
+            return PaymentInfo.Callback.from(PaymentResponseResult.FAIL, response.getReason());
+        }
+        return PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,8 +1,0 @@
-package com.loopers.application.payment;
-
-import com.loopers.domain.payment.dto.PaymentRequest;
-import com.loopers.domain.payment.dto.PaymentResponse;
-
-public interface PaymentProcessor {
-    PaymentResponse process(PaymentRequest request);
-}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRestoreService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRestoreService.java
@@ -1,6 +1,6 @@
 package com.loopers.application.payment;
 
-import com.loopers.application.order.PointProcessor;
+import com.loopers.application.order.PointUseService;
 import com.loopers.application.order.StockService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
@@ -15,7 +15,7 @@ public class PaymentRestoreService {
 
     private final UserCouponService userCouponService;
     private final StockService stockService;
-    private final PointProcessor pointProcessor;
+    private final PointUseService pointUseService;
 
     public void restore(Order order) {
         // 쿠폰 원복
@@ -28,6 +28,6 @@ public class PaymentRestoreService {
         }
 
         // 포인트 원복
-        pointProcessor.restoreWithLock(order.getUserId(), order.getPointAmount(), order.getId());
+        pointUseService.restoreWithLock(order.getUserId(), order.getPointAmount(), order.getId());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
@@ -3,6 +3,7 @@ package com.loopers.application.payment;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.dto.PaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,20 +29,19 @@ public class PaymentRetryService {
 
             PaymentResponse response = paymentGateway.getTransaction(payment.getTransactionKey());
 
-            String status = response.getStatus();
-            switch (status) {
-                case "SUCCESS":
-                    payment.setPaymentSuccess(status);
+            switch (response.getStatus()) {
+                case SUCCESS:
+                    payment.setPaymentSuccess(response.getReason());
                     order.markPaid();
                     log.info("결제 성공: orderId={} paymentId={}", order.getId(), payment.getId());
                     break;
-                case "FAIL":
-                    payment.setPaymentFailed(status);
+                case FAIL:
+                    payment.setPaymentFailed(response.getReason());
                     order.markPaymentFailed();
                     paymentRestoreService.restore(order);
                     log.info("결제 실패: orderId={} paymentId={}", order.getId(), payment.getId());
                     break;
-                case "PENDING":
+                case PENDING:
                     if (payment.getCreatedAt().isBefore(ZonedDateTime.now().minusMinutes(30))) {
                         payment.setPaymentFailed("결제가 지연되어 취소되었습니다.");
                         order.markPaymentFailed();

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
@@ -1,13 +1,12 @@
-package com.loopers.application.payment;
+package com.loopers.application.payment.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.dto.CardType;
 import com.loopers.domain.payment.dto.PaymentRequest;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentCommand {
@@ -17,6 +16,7 @@ public class PaymentCommand {
     public static class Create {
         private Long userId;
         private Long orderId;
+        private PaymentMethod method;
         private CardType cardType;
         private String cardNo;
         private int paymentAmount;
@@ -25,7 +25,7 @@ public class PaymentCommand {
             return PaymentRequest.create(
                     order.getOrderNo().toString(),
                     payment.getId(),
-                    payment.getMethod(),
+                    method,
                     cardType,
                     cardNo,
                     paymentAmount,
@@ -36,10 +36,10 @@ public class PaymentCommand {
 
     @Getter
     @Builder
-    public static class Modify {
+    public static class Callback {
         private String orderNo;
         private String transactionKey;
-        private String status;
+        private PaymentResponseResult result;
         private String reason;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
@@ -1,7 +1,8 @@
-package com.loopers.application.payment;
+package com.loopers.application.payment.dto;
 
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,11 +34,11 @@ public class PaymentInfo {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Callback {
-        private String result;
+        private PaymentResponseResult result;
         private String message;
 
-        public static Callback from(String result, String message) {
-            return new Callback(result, message);
+        public static PaymentInfo.Callback from(PaymentResponseResult result, String message) {
+            return new PaymentInfo.Callback(result, message);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
@@ -25,5 +25,14 @@ public class ProductCommand {
             return PageRequest.of(page, size);
         }
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Detail {
+        private Long userId;
+        private Long productId;
+    }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -4,6 +4,8 @@ import com.loopers.application.brand.BrandCacheService;
 import com.loopers.application.brand.BrandInfo;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.event.ProductEventPublisher;
+import com.loopers.domain.event.dto.ProductViewEvent;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.like.ProductLikeCount;
 import com.loopers.domain.product.Product;
@@ -32,6 +34,7 @@ public class ProductFacade {
     private final ProductCacheService productCacheService;
     private final BrandCacheService brandCacheService;
     private final LikeService likeService;
+    private final ProductEventPublisher productEventPublisher;
 
     @Transactional(readOnly = true)
     public ProductInfo.Summary getList(ProductCommand.Search command) {
@@ -67,8 +70,8 @@ public class ProductFacade {
         return ProductInfo.Summary.from(products, brands);
     }
 
-    public ProductInfo.Main getDetail(Long productId) {
-        Product product = productService.getDetail(productId);
+    public ProductInfo.Main getDetail(ProductCommand.Detail command) {
+        Product product = productService.getDetail(command.getProductId());
         if (product == null) {
             throw new CoreException(ErrorType.NOT_FOUND, MESSAGE_PRODUCT_NOT_FOUND);
         }
@@ -82,6 +85,8 @@ public class ProductFacade {
         if (stock == null) {
             throw new CoreException(ErrorType.NOT_FOUND, MESSAGE_STOCK_NOT_FOUND);
         }
+
+        productEventPublisher.publish(ProductViewEvent.of(command.getProductId(), command.getUserId()));
 
         return ProductInfo.Main.from(product, brand, stock);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -4,6 +4,8 @@ import com.loopers.application.brand.BrandCacheService;
 import com.loopers.application.brand.BrandInfo;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.like.ProductLikeCount;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.ProductSortType;
@@ -29,6 +31,7 @@ public class ProductFacade {
     private final ProductService productService;
     private final ProductCacheService productCacheService;
     private final BrandCacheService brandCacheService;
+    private final LikeService likeService;
 
     @Transactional(readOnly = true)
     public ProductInfo.Summary getList(ProductCommand.Search command) {
@@ -81,5 +84,13 @@ public class ProductFacade {
         }
 
         return ProductInfo.Main.from(product, brand, stock);
+    }
+
+    public void refreshLikeCounts() {
+        List<ProductLikeCount> productLikeCounts = likeService.countLikesGroupByProduct();
+
+        for (ProductLikeCount productLikeCount : productLikeCounts) {
+            productService.updateLikeCount(productLikeCount.getProductId(), productLikeCount.getLikeCount().intValue());
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/userAction/ExternalUserActionSender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/userAction/ExternalUserActionSender.java
@@ -1,0 +1,8 @@
+package com.loopers.application.userAction;
+
+import com.loopers.domain.event.dto.UserActionEvent;
+
+public interface ExternalUserActionSender {
+
+    void send(UserActionEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/CouponEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/CouponEventPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.CouponUseEvent;
+
+public interface CouponEventPublisher {
+
+    void publish(CouponUseEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/LikeEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/LikeEventPublisher.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.LikeDeleteEvent;
+import com.loopers.domain.event.dto.LikeAddEvent;
+
+public interface LikeEventPublisher {
+
+    void publish(LikeAddEvent event);
+
+    void publish(LikeDeleteEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/OrderEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/OrderEventPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.OrderCreatedEvent;
+
+public interface OrderEventPublisher {
+
+    void publish(OrderCreatedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/PaymentEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/PaymentEventPublisher.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.PaymentCallbackFailEvent;
+import com.loopers.domain.event.dto.PaymentFailEvent;
+import com.loopers.domain.event.dto.PaymentRequestSuccessEvent;
+import com.loopers.domain.event.dto.PaymentSuccessEvent;
+
+public interface PaymentEventPublisher {
+
+    void publish(PaymentRequestSuccessEvent event);
+
+    void publish(PaymentSuccessEvent event);
+
+    void publish(PaymentFailEvent event);
+
+    void publish(PaymentCallbackFailEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/PointHistoryEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/PointHistoryEventPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.PointHistoryEvent;
+
+public interface PointHistoryEventPublisher {
+
+    void publish(PointHistoryEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/ProductEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/ProductEventPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.event.dto.ProductViewEvent;
+
+public interface ProductEventPublisher {
+
+    void publish(ProductViewEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/CouponUseEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/CouponUseEvent.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CouponUseEvent {
+
+    private Long userCouponId;
+    private Long userId;
+
+    public static CouponUseEvent of(Long userCouponId, Long userId) {
+        return new CouponUseEvent(userCouponId, userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeAddEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeAddEvent.java
@@ -11,8 +11,9 @@ import lombok.NoArgsConstructor;
 public class LikeAddEvent {
 
     private Long productId;
+    private Long userId;
 
-    public static LikeAddEvent of(Long productId) {
-        return new LikeAddEvent(productId);
+    public static LikeAddEvent of(Long productId, Long userId) {
+        return new LikeAddEvent(productId, userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeAddEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeAddEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikeAddEvent {
+
+    private Long productId;
+
+    public static LikeAddEvent of(Long productId) {
+        return new LikeAddEvent(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeDeleteEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/LikeDeleteEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikeDeleteEvent {
+
+    private Long productId;
+
+    public static LikeDeleteEvent of(Long productId) {
+        return new LikeDeleteEvent(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/OrderCreatedEvent.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.event.dto;
+
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.dto.CardType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderCreatedEvent {
+
+    private Long orderId;
+    private Long userId;
+    private int paymentAmount;
+    private PaymentMethod method;
+    private CardType cardType;
+    private String cardNo;
+
+    public static OrderCreatedEvent of(Long orderId, Long userId, int paymentAmount, PaymentMethod method, CardType cardType, String cardNo) {
+        return new OrderCreatedEvent(orderId, userId, paymentAmount, method, cardType, cardNo);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentCallbackFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentCallbackFailEvent.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentCallbackFailEvent {
+
+    private Map<String, Object> params;
+    private String message;
+
+    public static PaymentCallbackFailEvent of(Map<String, Object> params, String message) {
+        return new PaymentCallbackFailEvent(params, message);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentFailEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentFailEvent {
+
+    private Long orderId;
+
+    public static PaymentFailEvent of(Long orderId) {
+        return new PaymentFailEvent(orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentRequestSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentRequestSuccessEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentRequestSuccessEvent {
+
+    private Long orderId;
+
+    public static PaymentRequestSuccessEvent of(Long orderId) {
+        return new PaymentRequestSuccessEvent(orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PaymentSuccessEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentSuccessEvent {
+
+    private Long orderId;
+
+    public static PaymentSuccessEvent of(Long orderId) {
+        return new PaymentSuccessEvent(orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PointHistoryEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/PointHistoryEvent.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.event.dto;
+
+import com.loopers.domain.point.PointType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PointHistoryEvent {
+
+    private Long userId;
+    private int amount;
+    private PointType type;
+    private Long orderId;
+
+    public static PointHistoryEvent of(Long userId, PointType type, int amount, Long orderId) {
+        return new PointHistoryEvent(userId, amount, type, orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/ProductViewEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/ProductViewEvent.java
@@ -8,12 +8,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class LikeDeleteEvent {
+public class ProductViewEvent {
 
     private Long productId;
     private Long userId;
 
-    public static LikeDeleteEvent of(Long productId, Long userId) {
-        return new LikeDeleteEvent(productId, userId);
+    public static ProductViewEvent of(Long productId, Long userId) {
+        return new ProductViewEvent(productId, userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/UserAction.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/UserAction.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.event.dto;
+
+public enum UserAction {
+    LIKE_ADD,
+    LIKE_DELETE,
+    ORDER,
+    VIEW
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/UserActionEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/dto/UserActionEvent.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserActionEvent {
+
+    private Long userId;
+    private UserAction action;
+    private Long targetId;
+    private ZonedDateTime timestamp;
+
+    public static UserActionEvent of(Long userId, UserAction action, Long targetId) {
+        return new UserActionEvent(userId, action, targetId, ZonedDateTime.now());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -2,10 +2,14 @@ package com.loopers.domain.like;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LikeRepository {
 
     Like findLike(Like like);
 
     Like save(Like like);
+
+    List<ProductLikeCount> countLikesGroupByProduct();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -9,6 +9,8 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class LikeService {
@@ -47,5 +49,9 @@ public class LikeService {
             return true;
         }
         return false;
+    }
+
+    public List<ProductLikeCount> countLikesGroupByProduct() {
+        return likeRepository.countLikesGroupByProduct();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeCount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeCount.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.like;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductLikeCount {
+    private Long productId;
+    private Long likeCount;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -21,6 +21,7 @@ public class OrderService {
         return orderRepository.save(order);
     }
 
+    @Transactional(readOnly = true)
     public Order getDetail(Long orderId) {
         Order order = orderRepository.getDetail(orderId);
         if (order == null) {
@@ -29,6 +30,7 @@ public class OrderService {
         return order;
     }
 
+    @Transactional(readOnly = true)
     public Order getDetailWithLock(Long orderId) {
         Order order = orderRepository.getDetailWithLock(orderId);
         if (order == null) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -46,16 +46,16 @@ public class OrderService {
 
     public void checkInitOrder(Order order, Long userId) {
         if (!order.getUserId().equals(userId)) {
-            throw new IllegalStateException("사용자 정보가 일치하지 않습니다.");
+            throw new CoreException(ErrorType.CONFLICT, "사용자 정보가 일치하지 않습니다.");
         }
         if (order.getStatus() != OrderStatus.CREATED) {
-            throw new IllegalStateException("주문 상태가 대기중이 아닙니다. status: " + order.getStatus());
+            throw new CoreException(ErrorType.CONFLICT, "주문 상태가 대기중이 아닙니다. status: " + order.getStatus());
         }
     }
 
     public void checkWaitingOrder(Order order) {
         if (order.getStatus() != OrderStatus.WAITING_PAYMENT) {
-            throw new IllegalStateException("주문 상태가 결제 대기중이 아닙니다. status: " + order.getStatus());
+            throw new CoreException(ErrorType.CONFLICT, "주문 상태가 결제 대기중이 아닙니다. status: " + order.getStatus());
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment;
+package com.loopers.domain.payment;
 
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
@@ -11,6 +11,5 @@ public interface PaymentGateway {
 
     PaymentResponse getTransaction(String transactionKey);
 
-    List<PaymentResponse> getTransactionsByOrder(String orderId);
-
+    List<PaymentResponse> getTransactionsByOrder(String orderNo);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -56,7 +56,7 @@ public class PaymentService {
         if (!checkPayment.getTransactionKey().equals(payment.getTransactionKey())) {
             throw new IllegalStateException("Transaction Key가 일치하지 않습니다.");
         }
-        if (payment.getStatus() == PaymentStatus.PENDING) {
+        if (payment.getStatus() != PaymentStatus.PENDING) {
             throw new IllegalStateException("결제 상태가 대기중이 아닙니다. status: " + payment.getStatus());
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PaymentResponse {
     private String transactionKey;
     private String orderNo;
-    private String status;
+    private PaymentResponseResult status;
     private String reason;
 
     public static PaymentResponse from(PgClientDto.PgResponse response) {
@@ -33,7 +33,7 @@ public class PaymentResponse {
     }
 
     public static PaymentResponse fail(String reason) {
-        return new PaymentResponse(null, null, "FAIL", reason);
+        return new PaymentResponse(null, null, PaymentResponseResult.FAIL, reason);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponseResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponseResult.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.payment.dto;
+
+public enum PaymentResponseResult {
+    SUCCESS, FAIL, PENDING
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointHistory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointHistory.java
@@ -32,15 +32,7 @@ public class PointHistory extends BaseEntity {
         this.orderId = orderId;
     }
 
-    public static PointHistory use(Long userId, int amount, Long orderId) {
-        return new PointHistory(userId, amount, PointType.USE, orderId);
-    }
-
-    public static PointHistory charge(Long userId, int amount) {
-        return new PointHistory(userId, amount, PointType.CHARGE, null);
-    }
-
-    public static PointHistory restore(Long userId, int amount, Long orderId) {
-        return new PointHistory(userId, amount, PointType.RESTORE, orderId);
+    public static PointHistory of(Long userId, int amount, PointType type, Long orderId) {
+        return new PointHistory(userId, amount, type, orderId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -21,6 +21,7 @@ public class Product extends BaseEntity {
     @Column(name = "price", nullable = false)
     private int price;
 
+    @Setter
     @Column(name = "like_count", nullable = false)
     private int likeCount;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -15,6 +15,8 @@ public interface ProductRepository {
 
     List<Product> findTopListByBrandId(Long brandId);
 
+    void updateLikeCount(Long productId, int likeCount);
+
     Stock findStockByProductId(Long productId);
     Stock findStockByProductIdWithLock(Long productId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -31,6 +31,10 @@ public class ProductService {
         return productRepository.findTopListByBrandId(brandId);
     }
 
+    public void updateLikeCount(Long productId, int likeCount) {
+        productRepository.updateLikeCount(productId, likeCount);
+    }
+
     @Transactional
     public void increaseLike(Long productId) {
         Product product = getDetail(productId);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
@@ -1,6 +1,7 @@
 package com.loopers.infrastructure.client.pg;
 
 import com.loopers.domain.payment.dto.PaymentRequest;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -30,7 +31,7 @@ public class PgClientDto {
     public record PgResponse(
             String transactionKey,
             String orderId,
-            String status,
+            PaymentResponseResult status,
             String reason
     ) { }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
@@ -27,7 +27,7 @@ public class PgPaymentGateway implements PaymentGateway {
         ApiResponse<PgClientDto.PgResponse> apiResponse = pgClient.request(request.toPgRequest(callbackUrl), userId);
         log.info("결제 요청 결과: {}", apiResponse.meta().result());
 
-        if (apiResponse.meta().result().equals(ApiResponse.Metadata.Result.FAIL)) {
+        if (apiResponse.meta().result() == ApiResponse.Metadata.Result.FAIL) {
             log.error("결제 요청 실패: errorCode={}, message={}", apiResponse.meta().errorCode(), apiResponse.meta().message());
             return PaymentResponse.fail(apiResponse.meta().message());
         }
@@ -39,7 +39,7 @@ public class PgPaymentGateway implements PaymentGateway {
         ApiResponse<PgClientDto.PgResponse> apiResponse = pgClient.getTransaction(transactionKey, userId);
         log.info("결제 조회 결과: {}", apiResponse.meta().result());
 
-        if (apiResponse.meta().result().equals(ApiResponse.Metadata.Result.FAIL)) {
+        if (apiResponse.meta().result() == ApiResponse.Metadata.Result.FAIL) {
             log.error("결제 조회 실패: errorCode={}, message={}", apiResponse.meta().errorCode(), apiResponse.meta().message());
             return PaymentResponse.fail(apiResponse.meta().message());
         }
@@ -52,7 +52,7 @@ public class PgPaymentGateway implements PaymentGateway {
         ApiResponse<PgClientDto.OrderResponse> apiResponse = pgClient.getTransactionsByOrder(orderNo, userId);
         log.info("주문 전체 결제 조회 결과: {}", apiResponse.meta().result());
 
-        if (apiResponse.meta().result().equals(ApiResponse.Metadata.Result.FAIL)) {
+        if (apiResponse.meta().result() == ApiResponse.Metadata.Result.FAIL) {
             log.error("주문 전체 결제 조회 실패: errorCode={}, message={}", apiResponse.meta().errorCode(), apiResponse.meta().message());
             return Collections.emptyList();
         }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.client.pg;
 
-import com.loopers.application.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
 import com.loopers.interfaces.api.ApiResponse;
@@ -48,8 +48,8 @@ public class PgPaymentGateway implements PaymentGateway {
     }
 
     @Override
-    public List<PaymentResponse> getTransactionsByOrder(String orderId) {
-        ApiResponse<PgClientDto.OrderResponse> apiResponse = pgClient.getTransactionsByOrder(orderId, userId);
+    public List<PaymentResponse> getTransactionsByOrder(String orderNo) {
+        ApiResponse<PgClientDto.OrderResponse> apiResponse = pgClient.getTransactionsByOrder(orderNo, userId);
         log.info("주문 전체 결제 조회 결과: {}", apiResponse.meta().result());
 
         if (apiResponse.meta().result().equals(ApiResponse.Metadata.Result.FAIL)) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/CouponSpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/CouponSpringEventPublisher.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.CouponEventPublisher;
+import com.loopers.domain.event.dto.CouponUseEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponSpringEventPublisher implements CouponEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(CouponUseEvent event) {
+        log.info("Coupon Use Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/LikeSpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/LikeSpringEventPublisher.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.LikeEventPublisher;
+import com.loopers.domain.event.dto.LikeDeleteEvent;
+import com.loopers.domain.event.dto.LikeAddEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeSpringEventPublisher implements LikeEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(LikeAddEvent event) {
+        log.info("Like Add Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publish(LikeDeleteEvent event) {
+        log.info("Like Delete Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/OrderSpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/OrderSpringEventPublisher.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.OrderEventPublisher;
+import com.loopers.domain.event.dto.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class OrderSpringEventPublisher implements OrderEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(OrderCreatedEvent event) {
+        log.info("Order Success Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/PaymentSpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/PaymentSpringEventPublisher.java
@@ -1,0 +1,45 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.*;
+import com.loopers.domain.event.dto.PaymentCallbackFailEvent;
+import com.loopers.domain.event.dto.PaymentFailEvent;
+import com.loopers.domain.event.dto.PaymentRequestSuccessEvent;
+import com.loopers.domain.event.dto.PaymentSuccessEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class PaymentSpringEventPublisher implements PaymentEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(PaymentRequestSuccessEvent event) {
+        log.info("Payment Request Success Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publish(PaymentSuccessEvent event) {
+        log.info("Payment Success Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publish(PaymentFailEvent event) {
+        log.info("Payment Fail Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publish(PaymentCallbackFailEvent event) {
+        log.info("Payment Callback Fail Event Published: {}", event);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/PointHistorySpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/PointHistorySpringEventPublisher.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.PointHistoryEventPublisher;
+import com.loopers.domain.event.dto.PointHistoryEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class PointHistorySpringEventPublisher implements PointHistoryEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(PointHistoryEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/ProductSpringEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/ProductSpringEventPublisher.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.ProductEventPublisher;
+import com.loopers.domain.event.dto.ProductViewEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class ProductSpringEventPublisher implements ProductEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(ProductViewEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,13 +1,24 @@
 package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.Like;
+import com.loopers.domain.like.ProductLikeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface LikeJpaRepository extends JpaRepository<Like, Long> {
 
     Optional<Like> findByUserIdAndProductId(Long userId, Long productId);
+
+    @Query("""
+        SELECT new com.loopers.domain.like.ProductLikeCount(l.productId, COUNT(l))
+        FROM Like l
+        WHERE l.deletedAt IS NULL
+        GROUP BY l.productId
+    """)
+    List<ProductLikeCount> countLikesGroupByProduct();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -2,8 +2,11 @@ package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.like.ProductLikeCount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -19,5 +22,10 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public Like save(Like like) {
         return likeJpaRepository.save(like);
+    }
+
+    @Override
+    public List<ProductLikeCount> countLikesGroupByProduct() {
+        return likeJpaRepository.countLikesGroupByProduct();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/ExternalOrderSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/ExternalOrderSenderImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class ExternalOrderSenderImpl implements ExternalOrderSender {
+
     @Override
     public void send(Order order) {
         log.info("외부 시스템 주문 전송: orderId={}, amount={}", order.getId(), order.getTotalAmount());

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.application.payment.PaymentAlertSender;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class PaymentAlertSenderImpl implements PaymentAlertSender {
+
+    @Value("${client.pg-simulator.x-user-id}")
+    private Long userId;
+
+    @Override
+    public void sendFail(Map<String, Object> params, Exception e) {
+        log.info("PG 결제 실패 알림 전송");
+        log.error("[PG 콜백 처리 실패]\n {}",
+                String.format(
+                        "userId=%s, transactionKey=%s\nerror=%s",
+                        userId,
+                        params.get("transactionKey"),
+                        e.getLocalizedMessage()
+                ));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
@@ -15,14 +15,14 @@ public class PaymentAlertSenderImpl implements PaymentAlertSender {
     private Long userId;
 
     @Override
-    public void sendFail(Map<String, Object> params, Exception e) {
+    public void sendFail(Map<String, Object> params, String message) {
         log.info("PG 결제 실패 알림 전송");
         log.error("[PG 콜백 처리 실패]\n {}",
                 String.format(
                         "userId=%s, transactionKey=%s\nerror=%s",
                         userId,
                         params.get("transactionKey"),
-                        e.getLocalizedMessage()
+                        message
                 ));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -4,8 +4,19 @@ import com.loopers.domain.product.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findAll(Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Product p
+        SET p.likeCount = :likeCount
+        WHERE p.id = :productId
+    """)
+    void updateLikeCount(@Param("productId") Long productId, @Param("likeCount") long likeCount);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -35,6 +35,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public void updateLikeCount(Long productId, int likeCount) {
+        productJpaRepository.updateLikeCount(productId, likeCount);
+    }
+
+    @Override
     public Stock findStockByProductId(Long productId) {
         return stockJpaRepository.findByProductId(productId).orElse(null);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userAction/ExternalUserActionSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userAction/ExternalUserActionSenderImpl.java
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.userAction;
+
+import com.loopers.application.userAction.ExternalUserActionSender;
+import com.loopers.domain.event.dto.UserActionEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ExternalUserActionSenderImpl implements ExternalUserActionSender {
+
+    @Override
+    public void send(UserActionEvent event) {
+        log.info("외부 시스템 유저 액션 전송: userId={}, action={}, targetId={}", event.getUserId(), event.getAction(), event.getTargetId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.order;
 
-import com.loopers.application.order.OrderCommand;
-import com.loopers.application.order.OrderInfo;
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.order.OrderStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -2,42 +2,13 @@ package com.loopers.interfaces.api.payment;
 
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-
-import static com.loopers.support.constants.HeaderConstants.USER_USER_ID_HEADER;
 
 @Tag(name = "Payment V1 API", description = "결제 관련 API")
 public interface PaymentV1ApiSpec {
-
-    @Operation(summary = "결제 요청", description = "결제 요청 처리")
-    ApiResponse<PaymentV1Dto.PaymentResponse.Main> payment(
-            @Parameter(description = "사용자 식별 USER_ID 헤더", example = "1")
-            @RequestHeader(USER_USER_ID_HEADER) Long userId,
-
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "기본 예시",
-                                    value = """
-                                        {
-                                          "orderId": 1,
-                                          "cardType": "SAMSUNG",
-                                          "cardNo": "1234-5678-9814-1451",
-                                          "paymentAmount": 5000
-                                        }
-                                    """
-                            )
-                    )
-            )
-            @RequestBody PaymentV1Dto.PaymentRequest.Create request
-    );
 
     @Operation(summary = "결제 결과 callback", description = "결제 결과 처리")
     ApiResponse<?> callback(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -58,6 +58,6 @@ public interface PaymentV1ApiSpec {
                             )
                     )
             )
-            @RequestBody PaymentV1Dto.PaymentRequest.Modify request
+            @RequestBody PaymentV1Dto.PaymentRequest.Callback request
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -14,15 +14,6 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
 
     private final PaymentFacade paymentFacade;
 
-    @PostMapping
-    @Override
-    public ApiResponse<PaymentV1Dto.PaymentResponse.Main> payment(
-            Long userId,
-            PaymentV1Dto.PaymentRequest.Create request
-    ) {
-        return ApiResponse.success(PaymentV1Dto.PaymentResponse.Main.from(paymentFacade.payment(request.toCommand(userId))));
-    }
-
     @PostMapping("/callback")
     @Override
     public ApiResponse<String> callback(PaymentV1Dto.PaymentRequest.Callback request) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -25,13 +25,8 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
 
     @PostMapping("/callback")
     @Override
-    public ApiResponse<?> callback(PaymentV1Dto.PaymentRequest.Modify request) {
-        PaymentV1Dto.PaymentResponse.Callback response = PaymentV1Dto.PaymentResponse.Callback.from(paymentFacade.paymentCallback(request.toCommand()));
-        if ("SUCCESS".equalsIgnoreCase(response.result())) {
-            return ApiResponse.success(response);
-        } else {
-            String errorMessage = response.message();
-            return ApiResponse.fail("FAIL", errorMessage);
-        }
+    public ApiResponse<String> callback(PaymentV1Dto.PaymentRequest.Callback request) {
+        paymentFacade.paymentCallback(request.toCommand());
+        return ApiResponse.success("SUCCESS");
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -1,8 +1,9 @@
 package com.loopers.interfaces.api.payment;
 
-import com.loopers.application.payment.PaymentCommand;
-import com.loopers.application.payment.PaymentInfo;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.payment.dto.CardType;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -28,17 +29,17 @@ public class PaymentV1Dto {
             }
         }
 
-        public record Modify(
+        public record Callback(
                 String orderNo,
                 String transactionKey,
-                String status,
+                PaymentResponseResult status,
                 String reason
         ) {
-            public PaymentCommand.Modify toCommand() {
-                return PaymentCommand.Modify.builder()
+            public PaymentCommand.Callback toCommand() {
+                return PaymentCommand.Callback.builder()
                         .orderNo(orderNo)
                         .transactionKey(transactionKey)
-                        .status(status)
+                        .result(status)
                         .reason(reason)
                         .build();
             }
@@ -61,18 +62,6 @@ public class PaymentV1Dto {
                         info.getPaymentAmount(),
                         info.getStatus().toString(),
                         info.getTransactionKey()
-                );
-            }
-        }
-
-        public record Callback(
-                String result,
-                String message
-        ) {
-            public static PaymentResponse.Callback from(PaymentInfo.Callback main) {
-                return new PaymentResponse.Callback(
-                        main.getResult(),
-                        main.getMessage()
                 );
             }
         }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -8,6 +8,9 @@ import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static com.loopers.support.constants.HeaderConstants.USER_USER_ID_HEADER;
 
 @Tag(name = "Product V1 API", description = "상품 조회 API")
 public interface ProductV1ApiSpec {
@@ -23,6 +26,9 @@ public interface ProductV1ApiSpec {
     @Operation(summary = "상품 정보 조회", description = "상품 ID 로 상품 상세 정보 조회")
     ApiResponse<ProductV1Dto.ProductResponse.Detail> getDetail(
             @Parameter(description = "상품 ID", example = "1")
-            @PathVariable Long productId
+            @PathVariable Long productId,
+
+            @Parameter(description = "사용자 식별 USER_ID 헤더", example = "1")
+            @RequestHeader(value = USER_USER_ID_HEADER, required = false) Long userId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,10 +1,13 @@
 package com.loopers.interfaces.api.product;
 
+import com.loopers.application.product.ProductCommand;
 import com.loopers.application.product.ProductFacade;
 import com.loopers.interfaces.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import static com.loopers.support.constants.HeaderConstants.USER_USER_ID_HEADER;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,6 +17,7 @@ public class ProductV1Controller implements ProductV1ApiSpec {
     private final ProductFacade productFacade;
 
     @GetMapping
+    @Override
     public ApiResponse<ProductV1Dto.ProductResponse.Summary> getList(
             @Valid ProductV1Dto.ProductRequest.Summary request
     ) {
@@ -21,9 +25,12 @@ public class ProductV1Controller implements ProductV1ApiSpec {
     }
 
     @GetMapping("/{productId}")
+    @Override
     public ApiResponse<ProductV1Dto.ProductResponse.Detail> getDetail(
-            @PathVariable Long productId
+            @PathVariable Long productId,
+            @RequestHeader(value = USER_USER_ID_HEADER, required = false) Long userId
     ) {
-        return ApiResponse.success(ProductV1Dto.ProductResponse.Detail.from(productFacade.getDetail(productId)));
+        ProductCommand.Detail command = ProductCommand.Detail.builder().productId(productId).userId(userId).build();
+        return ApiResponse.success(ProductV1Dto.ProductResponse.Detail.from(productFacade.getDetail(command)));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/CouponEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/CouponEventHandler.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.application.order.CouponUseService;
+import com.loopers.domain.event.dto.CouponUseEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponEventHandler {
+
+    private final CouponUseService couponUseService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handle(CouponUseEvent event) {
+        log.info("Coupon Use Event Handling: userCouponId={}, userId={}", event.getUserCouponId(), event.getUserId());
+        couponUseService.use(event.getUserCouponId(), event.getUserId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/LikeEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/LikeEventHandler.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.domain.event.dto.LikeAddEvent;
+import com.loopers.domain.event.dto.LikeDeleteEvent;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeEventHandler {
+
+    private final ProductService productService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeAdded(LikeAddEvent event) {
+        productService.increaseLike(event.getProductId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeDeleted(LikeDeleteEvent event) {
+        productService.decreaseLike(event.getProductId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/OrderCreatedEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/OrderCreatedEventHandler.java
@@ -1,0 +1,42 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.application.order.ExternalOrderSender;
+import com.loopers.application.payment.PaymentFacade;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.domain.event.dto.OrderCreatedEvent;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedEventHandler {
+
+    private final PaymentFacade paymentFacade;
+    private final ExternalOrderSender externalOrderSender;
+    private final OrderService orderService;
+
+    @Async
+    @TransactionalEventListener
+    public void handlePayment(OrderCreatedEvent event) {
+        PaymentCommand.Create command = PaymentCommand.Create.builder()
+                .userId(event.getUserId())
+                .orderId(event.getOrderId())
+                .method(event.getMethod())
+                .cardType(event.getCardType())
+                .cardNo(event.getCardNo())
+                .paymentAmount(event.getPaymentAmount())
+                .build();
+        paymentFacade.payment(command);
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handleExternalSend(OrderCreatedEvent event) {
+        Order order = orderService.getDetail(event.getOrderId());
+        externalOrderSender.send(order);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/PaymentEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/PaymentEventHandler.java
@@ -1,0 +1,55 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.application.order.ExternalOrderSender;
+import com.loopers.application.payment.PaymentAlertSender;
+import com.loopers.application.payment.PaymentRestoreService;
+import com.loopers.domain.event.dto.PaymentCallbackFailEvent;
+import com.loopers.domain.event.dto.PaymentFailEvent;
+import com.loopers.domain.event.dto.PaymentRequestSuccessEvent;
+import com.loopers.domain.event.dto.PaymentSuccessEvent;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventHandler {
+
+    private final OrderService orderService;
+    private final ExternalOrderSender externalOrderSender;
+    private final PaymentRestoreService paymentRestoreService;
+    private final PaymentAlertSender paymentAlertSender;
+
+    @Async
+    @TransactionalEventListener
+    public void handle(PaymentRequestSuccessEvent event) {
+        Order order = orderService.getDetail(event.getOrderId());
+        order.markWaitingPayment();
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handle(PaymentSuccessEvent event) {
+        Order order = orderService.getDetail(event.getOrderId());
+        order.markPaid();
+        externalOrderSender.send(order);
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handle(PaymentFailEvent event) {
+        Order order = orderService.getDetail(event.getOrderId());
+        order.markPaymentFailed();
+        paymentRestoreService.restore(order);
+        externalOrderSender.send(order);
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handle(PaymentCallbackFailEvent event) {
+        paymentAlertSender.sendFail(event.getParams(), event.getMessage());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/PointHistoryEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/PointHistoryEventHandler.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.domain.event.dto.PointHistoryEvent;
+import com.loopers.domain.point.PointHistory;
+import com.loopers.domain.point.PointService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointHistoryEventHandler {
+
+    private final PointService pointService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PointHistoryEvent event) {
+        PointHistory history = PointHistory.of(event.getUserId(), event.getAmount(), event.getType(), event.getOrderId());
+        pointService.saveHistory(history);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/UserActionEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/UserActionEventHandler.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -19,24 +21,28 @@ public class UserActionEventHandler {
     private final ExternalUserActionSender externalUserActionSender;
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLikeAdded(LikeAddEvent event) {
         externalUserActionSender.send(UserActionEvent.of(event.getUserId(), LIKE_ADD, event.getProductId()));
     }
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLikeDeleted(LikeDeleteEvent event) {
         externalUserActionSender.send(UserActionEvent.of(event.getUserId(), LIKE_DELETE, event.getProductId()));
     }
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderCreated(OrderCreatedEvent event) {
         externalUserActionSender.send(UserActionEvent.of(event.getUserId(), ORDER, event.getOrderId()));
     }
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProductViewed(ProductViewEvent event) {
         externalUserActionSender.send(UserActionEvent.of(event.getUserId(), VIEW, event.getProductId()));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/UserActionEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/listener/UserActionEventHandler.java
@@ -1,0 +1,44 @@
+package com.loopers.interfaces.event.listener;
+
+import com.loopers.application.userAction.ExternalUserActionSender;
+import com.loopers.domain.event.dto.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static com.loopers.domain.event.dto.UserAction.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserActionEventHandler {
+
+    private final ExternalUserActionSender externalUserActionSender;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeAdded(LikeAddEvent event) {
+        externalUserActionSender.send(UserActionEvent.of(event.getUserId(), LIKE_ADD, event.getProductId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeDeleted(LikeDeleteEvent event) {
+        externalUserActionSender.send(UserActionEvent.of(event.getUserId(), LIKE_DELETE, event.getProductId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderCreatedEvent event) {
+        externalUserActionSender.send(UserActionEvent.of(event.getUserId(), ORDER, event.getOrderId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductViewed(ProductViewEvent event) {
+        externalUserActionSender.send(UserActionEvent.of(event.getUserId(), VIEW, event.getProductId()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/ProductLikeScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/ProductLikeScheduler.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.scheduler;
+
+import com.loopers.application.product.ProductFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductLikeScheduler {
+
+    private final ProductFacade productFacade;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 0시
+    public void refreshLikeCounts() {
+        productFacade.refreshLikeCounts();
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/CouponUseServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/CouponUseServiceConcurrencyTest.java
@@ -61,7 +61,7 @@ class CouponUseServiceConcurrencyTest {
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
-                    couponUseService.use(userCoupon.getId(), userCoupon.getUserId(), 10000);
+                    couponUseService.use(userCoupon.getId(), userCoupon.getUserId());
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     System.out.println("[FAIL]: "+e.getMessage());

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderValidationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderValidationServiceTest.java
@@ -1,0 +1,179 @@
+package com.loopers.application.order;
+
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderValidationServiceTest {
+
+    @Mock
+    private CouponUseService couponUseService;
+    @Mock
+    private StockService stockService;
+    @Mock
+    private PointUseService pointUseService;
+
+    @InjectMocks
+    private OrderValidationService orderValidationService;
+
+    @DisplayName("쿠폰/재고/포인트가 정상적으로 차사감되면 주문 엔티티에 반영된다.")
+    @Test
+    void whenValidSuccess_thenOrderUpdated() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+
+        // act
+        orderValidationService.validate(command, order);
+
+        // assert
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verify(pointUseService).useWithLock(userId, usePoint, order.getId());
+
+        assertThat(order.getDiscountAmount()).isEqualTo(discountAmount);
+        assertThat(order.getPointAmount()).isEqualTo(usePoint);
+    }
+
+    @DisplayName("쿠폰 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenCouponUseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenThrow(new RuntimeException("쿠폰 차감 실패"));
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verifyNoInteractions(stockService);
+        verifyNoInteractions(pointUseService);
+    }
+
+    @DisplayName("재고 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenStockDecreaseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+        doThrow(new RuntimeException("재고 차감 실패")).when(stockService).decrease(anyLong(), anyInt());
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verifyNoInteractions(pointUseService);
+    }
+
+    @DisplayName("포인트 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenPointUseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+        doThrow(new RuntimeException("포인트 차감 실패")).when(pointUseService).useWithLock(anyLong(), anyInt(), anyLong());
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verify(pointUseService).useWithLock(userId, usePoint, order.getId());
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
@@ -1,15 +1,12 @@
 package com.loopers.application.order;
 
 import com.loopers.domain.point.Point;
-import com.loopers.domain.point.PointHistory;
-import com.loopers.infrastructure.point.PointHistoryJpaRepository;
 import com.loopers.infrastructure.point.PointJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -27,8 +24,6 @@ class PointUseServiceConcurrencyTest {
     // orm--
     @Autowired
     private PointJpaRepository pointJpaRepository;
-    @Autowired
-    private PointHistoryJpaRepository pointHistoryJpaRepository;
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
@@ -133,10 +128,6 @@ class PointUseServiceConcurrencyTest {
             Point result = pointJpaRepository.findById(point.getId()).orElseThrow();
             System.out.println("[남은 포인트]: " + result.getPoint());
             assertThat(result.getPoint()).isEqualTo(initialPoint-(2*usePoint));
-
-            List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(1L);
-            System.out.println("[포인트 사용 이력 크기]: " + histories.size());
-            assertThat(histories).hasSize(2);
         }
 
         @DisplayName("포인트가 0이라면 모든 주문에 대해 포인트 사용이 실패한다.")
@@ -186,10 +177,6 @@ class PointUseServiceConcurrencyTest {
             Point result = pointJpaRepository.findById(point.getId()).orElseThrow();
             System.out.println("[남은 포인트]: " + result.getPoint());
             assertThat(result.getPoint()).isEqualTo(initialPoint);
-
-            List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(1L);
-            System.out.println("[포인트 사용 이력 크기]: " + histories.size());
-            assertThat(histories).hasSize(0);
         }
     }
 
@@ -243,10 +230,6 @@ class PointUseServiceConcurrencyTest {
             Point result = pointJpaRepository.findById(point.getId()).orElseThrow();
             System.out.println("[남은 포인트]: " + result.getPoint());
             assertThat(result.getPoint()).isEqualTo(initialPoint-(successCount.get()*usePoint));
-
-            List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(1L);
-            System.out.println("[포인트 사용 이력 크기]: " + histories.size());
-            assertThat(histories).hasSize(successCount.get());
         }
 
         @DisplayName("포인트가 부족하다면 포인트가 유효한 주문에 대해서만 포인트가 사용된다.")
@@ -296,10 +279,6 @@ class PointUseServiceConcurrencyTest {
             Point result = pointJpaRepository.findById(point.getId()).orElseThrow();
             System.out.println("[남은 포인트]: " + result.getPoint());
             assertThat(result.getPoint()).isEqualTo(initialPoint-(2*usePoint));
-
-            List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(1L);
-            System.out.println("[포인트 사용 이력 크기]: " + histories.size());
-            assertThat(histories).hasSize(2);
         }
 
         @DisplayName("포인트가 0이라면 모든 주문에 대해 포인트 사용이 실패한다.")
@@ -349,10 +328,6 @@ class PointUseServiceConcurrencyTest {
             Point result = pointJpaRepository.findById(point.getId()).orElseThrow();
             System.out.println("[남은 포인트]: " + result.getPoint());
             assertThat(result.getPoint()).isEqualTo(initialPoint);
-
-            List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(1L);
-            System.out.println("[포인트 사용 이력 크기]: " + histories.size());
-            assertThat(histories).hasSize(0);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("포인트 사용에 락 적용 시")
 @SpringBootTest
-class PointProcessorConcurrencyTest {
+class PointUseServiceConcurrencyTest {
     // sut --
     @Autowired
-    private PointProcessor pointProcessor;
+    private PointUseService pointUseService;
 
     // orm--
     @Autowired
@@ -64,7 +64,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -109,7 +109,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -162,7 +162,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -220,7 +220,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -272,7 +272,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -325,7 +325,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
@@ -28,8 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -224,7 +223,7 @@ class PaymentFacadeIntegrationTest {
             paymentFacade.paymentCallback(command);
 
             // assert
-            verify(paymentAlertSender).sendFail(anyMap(), any(RuntimeException.class));
+            verify(paymentAlertSender).sendFail(anyMap(), anyString());
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.order.ExternalOrderSender;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.application.payment.dto.PaymentInfo;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.CardType;
+import com.loopers.domain.payment.dto.PaymentRequest;
+import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
+import com.loopers.infrastructure.client.pg.PgClientDto;
+import com.loopers.infrastructure.order.OrderJpaRepository;
+import com.loopers.infrastructure.payment.PaymentJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class PaymentFacadeIntegrationTest {
+
+    // orm --
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+    @Autowired
+    private PaymentJpaRepository paymentJpaRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    // sut--
+    @Autowired
+    private PaymentFacade paymentFacade;
+
+    @MockitoBean
+    private PaymentGatewayService paymentGatewayService;
+    @MockitoBean
+    private PaymentRestoreService paymentRestoreService;
+    @MockitoBean
+    private ExternalOrderSender externalOrderSender;
+    @MockitoBean
+    private PaymentAlertSender paymentAlertSender;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    final Long userId = 1L;
+    Order order;
+    Payment payment;
+
+    @BeforeEach
+    void setUp() {
+        OrderItem item = OrderItem.of(1L, 1, 10000);
+        order = orderJpaRepository.save(Order.create(userId, 1L, List.of(item)));
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 결제_요청_시 {
+        PaymentCommand.Create command;
+
+        @BeforeEach
+        void setUp() {
+            payment = Payment.createBuilder().userId(userId).paymentAmount(order.getTotalAmount()).build();
+            command = PaymentCommand.Create.builder()
+                    .userId(userId)
+                    .orderId(order.getId())
+                    .method(PaymentMethod.CARD)
+                    .cardType(CardType.SAMSUNG)
+                    .cardNo("1111-2222-3333-4444")
+                    .paymentAmount(order.getTotalAmount())
+                    .build();
+        }
+
+        @DisplayName("PG 결제가 성공하면 Payment 는 PENDING 상태가 된다.")
+        @Test
+        void whenPgSuccess_thenPaymentPending() {
+            // arrange
+            PgClientDto.PgResponse pgResponse = new PgClientDto.PgResponse(
+                    "TR:9577c5",
+                    order.getOrderNo().toString(),
+                    PaymentResponseResult.SUCCESS,
+                    "요청 완료"
+            );
+            PaymentResponse response = PaymentResponse.from(pgResponse);
+
+            when(paymentGatewayService.requestPayment(any(PaymentRequest.class)))
+                    .thenReturn(response);
+
+            // act
+            PaymentInfo.Main result = paymentFacade.payment(command);
+
+            // assert
+            Payment payment = paymentJpaRepository.findById(result.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+            assertThat(payment.getTransactionKey()).isEqualTo(pgResponse.transactionKey());
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.WAITING_PAYMENT);
+
+            verify(paymentGatewayService).requestPayment(any(PaymentRequest.class));
+        }
+
+        @Test
+        @DisplayName("주문 상태가 CREATED 가 아닌 경우 결제요청은 실패한다.")
+        void whenOrderStatusIsNotCreated_thenFail() {
+            // arrange
+            order.markWaitingPayment();
+            orderJpaRepository.save(order);
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> paymentFacade.payment(command));
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+
+    @Nested
+    class 결제_콜백_시 {
+        String transactionKey = "TR:9577c5";
+
+        @BeforeEach
+        void setUp() {
+            order.markWaitingPayment();
+            orderJpaRepository.save(order);
+            payment = Payment.createBuilder()
+                    .userId(userId)
+                    .orderId(order.getId())
+                    .paymentAmount(order.getTotalAmount())
+                    .method(PaymentMethod.CARD)
+                    .build();
+            payment.setPaymentPending(transactionKey);
+            paymentJpaRepository.save(payment);
+        }
+
+        @DisplayName("PG 콜백이 SUCCESS 인 경우, Payment와 Order는 결제대기 상태로 바뀌고 외부 전송이 호출된다.")
+        @Test
+        void whenCallbackSuccess_thenPaymentAndOrderSuccess() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.SUCCESS)
+                    .reason("승인 완료")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenReturn(PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            Payment updatedPayment = paymentJpaRepository.findById(payment.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(updatedPayment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.PAID);
+
+            verify(externalOrderSender).send(any(Order.class));
+        }
+
+        @Test
+        @DisplayName("PG 콜백이 FAIL 인 경우, Payment와 Order는 실패 상태로 바뀌고 원복 로직이 실행된다.")
+        void whenCallbackFail_thenPaymentAndOrderFailed() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.FAIL)
+                    .reason("한도 초과")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenReturn(PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            Payment updatedPayment = paymentJpaRepository.findById(payment.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(updatedPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.PAYMENT_FAILED);
+
+            verify(paymentRestoreService).restore(any(Order.class));
+        }
+
+        @Test
+        @DisplayName("PG 조회에서 예외가 발생하는 경우, 알림이 전송된다.")
+        void whenExceptionOccur_thenAlertSend() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.SUCCESS)
+                    .reason("승인 완료")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenThrow(new RuntimeException("PG 서버 오류"));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            verify(paymentAlertSender).sendFail(anyMap(), any(RuntimeException.class));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.user.*;
-import com.loopers.infrastructure.point.PointHistoryJpaRepository;
 import com.loopers.infrastructure.point.PointJpaRepository;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.support.error.CoreException;
@@ -11,7 +10,6 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,8 +20,6 @@ class PointServiceIntegrationTest {
     // orm --
     @Autowired
     private PointJpaRepository pointJpaRepository;
-    @Autowired
-    private PointHistoryJpaRepository pointHistoryJpaRepository;
     @Autowired
     private UserJpaRepository userJpaRepository;
 
@@ -72,11 +68,6 @@ class PointServiceIntegrationTest {
                 // assert
                 Optional<Point> saved = pointJpaRepository.findByUserId(user.getId());
                 assertThat(saved.get().getPoint()).isEqualTo(current+amount);
-
-                List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(point.getUserId());
-                assertThat(histories).hasSize(1);
-                assertThat(histories.get(0).getAmount()).isEqualTo(amount);
-                assertThat(histories.get(0).getType()).isEqualTo(PointType.CHARGE);
             }
         }
 
@@ -172,11 +163,6 @@ class PointServiceIntegrationTest {
                 // assert
                 Optional<Point> saved = pointJpaRepository.findByUserId(user.getId());
                 assertThat(saved.get().getPoint()).isEqualTo(current-amount);
-
-                List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(point.getUserId());
-                assertThat(histories).hasSize(1);
-                assertThat(histories.get(0).getAmount()).isEqualTo(amount);
-                assertThat(histories.get(0).getType()).isEqualTo(PointType.USE);
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,8 @@ subprojects {
     }
 }
 
-// module-container 는 task 를 실행하지 않도록 한다.
+// module-container(apps, modules, supports), pg-simulator 는 task 를 실행하지 않도록 한다.
 project("apps") { tasks.configureEach { enabled = false } }
+project(":apps:pg-simulator") { tasks.configureEach { enabled = false } }
 project("modules") { tasks.configureEach { enabled = false } }
 project("supports") { tasks.configureEach { enabled = false } }


### PR DESCRIPTION
## 📌 Summary
- PG 연동 흐름 수정
- 주문-결제 로직 하나의 API 로 병합
- 주문 성공 시 결제로직, 데이터 플랫폼 전송 로직 이벤트 분리
- 결제 로직 내 주문 상태 변경 로직 이벤트 분리
- 좋아요 등록/취소 시 집계 로직 이벤트 분리
- 좋아요 집계 스케줄러 추가


## 💬 Review Points

### 레이어 설정
현재 이벤트 관련 클래스들을 다음과 같이 배치했습니다. 
구조나 네이밍이 적절할까요?
```
/domain
└── /event
    ├── xxEventPublisher (인터페이스)
    └── /dto
        └── xxEvent

/infrastructure
└── /event
    └── xxSpringEventPublisher (구현체)

/interfaces
└── /event
    └── /listener
        └── xxEventHandler
```


### 트랜잭션 분리
트랜잭션을 다음과 같이 분리했습니다.
- **핵심 로직**: 주문 생성, 주문 검증, 결제 생성, 결제 검증
- **후속 작업**: 쿠폰 사용, 포인트 이력 저장, 결제 요청, 리소스 원복, 다른 도메인 상태 변경, 외부 API 호출

주문 시에는 아래처럼 처리합니다.
```
주문 {
	주문 생성
	쿠폰 조회 & 계산
	 -> 쿠폰 사용 이벤트 발행
	재고 조회 & 차감
	포인트 조회 & 차감
	주문 생성 이벤트 발행
}
```

여기서 쿠폰 사용을 이벤트로 분리했는데 사실 핵심 로직에 쿠폰 사용도 포함시켜야 하는 게 맞지 않나 아직도 고민이 됩니다.
그래서 쿠폰에 선점 상태를 추가하면 어떨까 라는 생각을 해봤습니다.
주문 트랜잭션 내에서 사용자 쿠폰 검증 및 ***선점 상태***로 변경을 수행하고,
결제 완료 이벤트 내에서 ***사용 상태***로 변경하는 방식은 어떨까요?
선점 상태를 추가하는게 괜찮다면 같은 방식으로 포인트에도 적용하고자 합니다.

그런데 재고의 경우엔 경합이 많이 일어나는 리소스라고 생각되어서 선점 상태를 어떻게 가져가야할지 고민이 됩니다. 재고 차감 이력 테이블을 추가해 선점 상태를 가지도록 하던지 아니면 레디스 등 캐시에 저장하는 방식을 생각해봤는데 어떤 방식이 좋을까요??

### 멱등한 이벤트 처리
동일한 이벤트가 여러 건 발행될 경우 어떻게 제어할 수 있을까요?
일단 결제 로직 내에서 주문 상태에 비관적락을 걸어 조회해온 다음 처리하도록 추가해봤는데 이런 식으로 하는게 맞을까요?
```java
@Transactional
public PaymentInfo.Main payment(PaymentCommand.Create command) {
    // 주문 상태 조회
    Order order = orderService.getDetailWithLock(command.getOrderId());
    orderService.checkInitOrder(order, command.getUserId());

    // 결제 생성
    Payment payment = paymentService.create(command.getUserId(), order.getId(), order.getPaymentAmount(), command.getMethod());
```
그리고 저런 로직으로 연결되는 게 아닌, 단순 외부 데이터 플랫폼 전달 수준이면 어떻게 처리하는게 좋을까요?

### 유저 행동 로깅

현재 유저의 행동 로깅을 다음과 같이 이벤트로 분리해서 처리해보았습니다.
`상품 조회, 좋아요, 주문 시 이벤트 발행 → 유저 행동 핸들러에서 받아서 전송` [UserActionEventHandler](https://github.com/hyunn12/e-commerce-project/pull/23/files#diff-51471c59d3ea5b16c676f7d983cd8edd946058d5997b63634ebf0f1dc6cbe1ea)
그런데 클릭 이벤트의 경우 별도의 API를 호출하도록 해야할 것으로 생각되는데요.
그렇게 되면 트래픽이 몰릴 경우 서버가 너무 느려지거나 하지는 않을까요?
그리고 이렇게 서버에서 유저의 행동을 로깅하는 방식이 일반적인가요??
어떤 식으로 처리하는게 좋을지 고민입니다.


## ✅ Checklist
### 🧾 주문 ↔ 결제

- [x]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [x]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [x]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다.

### ❤️ 좋아요 ↔ 집계

- [x]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [x]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통

- [x]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
- [x]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.

## 📎 References
- https://wonit.tistory.com/633
- https://mangkyu.tistory.com/292