### PR TITLE
[volume-7] 주문/결제 흐름 개선 및 PG 연동 리팩토링

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import jakarta.transaction.Transactional;
@@ -14,14 +16,14 @@ import org.springframework.stereotype.Component;
 public class OrderFacade {
 
     private final OrderService orderService;
-    private final OrderProcessor orderProcessor;
+    private final OrderValidationService orderValidateService;
 
     @Transactional
     public OrderInfo.Main create(OrderCommand.Create command) {
         Order order = orderService.create(command.toDomain());
 
         try {
-            orderProcessor.process(command, order);
+            orderValidateService.validate(command, order);
         } catch (Exception ex) {
             log.error("주문 처리 중 예외 발생: {}", ex.getLocalizedMessage());
             order.markOrderFailed();

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
@@ -5,6 +5,8 @@ import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -14,6 +16,7 @@ public class OrderValidationService {
     private final StockService stockService;
     private final PointUseService pointUseService;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void validate(OrderCommand.Create command, Order order) {
         // 쿠폰 조회 및 사용
         int discountAmount = 0;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderValidationService.java
@@ -1,5 +1,6 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.dto.OrderCommand;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import lombok.RequiredArgsConstructor;
@@ -7,13 +8,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OrderProcessor {
+public class OrderValidationService {
 
     private final CouponUseService couponUseService;
     private final StockService stockService;
-    private final PointProcessor pointProcessor;
+    private final PointUseService pointUseService;
 
-    public void process(OrderCommand.Create command, Order order) {
+    public void validate(OrderCommand.Create command, Order order) {
         // 쿠폰 조회 및 사용
         int discountAmount = 0;
         if (command.getUserCouponId() != null) {
@@ -27,7 +28,7 @@ public class OrderProcessor {
         }
 
         // 포인트 조회 및 차감
-        pointProcessor.useWithLock(command.getUserId(), command.getPoint(), order.getId());
+        pointUseService.useWithLock(command.getUserId(), command.getPoint(), order.getId());
         order.setPointAmount(command.getPoint());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/PointUseService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/PointUseService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class PointProcessor {
+public class PointUseService {
 
     private final PointService pointService;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderInfo.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentAlertSender.java
@@ -1,0 +1,8 @@
+package com.loopers.application.payment;
+
+import java.util.Map;
+
+public interface PaymentAlertSender {
+
+    void sendFail(Map<String, Object> params, Exception e);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -7,7 +7,8 @@ import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentService;
-import com.loopers.domain.payment.dto.PaymentResult;
+import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +43,10 @@ public class PaymentFacade {
         Payment payment = paymentService.create(command.getUserId(), order.getId(), order.getPaymentAmount(), command.getMethod());
 
         // PG 결제 요청
-        paymentGatewayService.process(command.toRequest(order, payment));
+        PaymentResponse response = paymentGatewayService.requestPayment(command.toRequest(order, payment));
+        if (response.getStatus() == PaymentResponseResult.SUCCESS) {
+            payment.setPaymentPending(response.getTransactionKey());
+        }
 
         return PaymentInfo.Main.from(payment);
     }
@@ -52,7 +56,7 @@ public class PaymentFacade {
         try {
             // PG 결제 조회
             PaymentInfo.Callback info = paymentGatewayService.getTransaction(command.getTransactionKey());
-            if (info.getResult().equals(PaymentResult.FAIL)) {
+            if (info.getResult() == PaymentResponseResult.FAIL) {
                 throw new CoreException(ErrorType.BAD_REQUEST, "결제 결과가 일치하지 않습니다.");
             }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
@@ -8,6 +8,7 @@ import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResult;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +39,7 @@ public class PaymentGatewayService {
 
         // 결제 API 호출
         PaymentResponse response = paymentGateway.requestPayment(request, callbackUrl);
-        if (response.getStatus().equals("SUCCESS")) {
+        if (response.getStatus().equals(PaymentResult.SUCCESS)) {
             payment.setPaymentPending(response.getTransactionKey());
         }
     }
@@ -56,9 +57,9 @@ public class PaymentGatewayService {
 
     public PaymentInfo.Callback getTransaction(String transactionKey) {
         PaymentResponse response = paymentGateway.getTransaction(transactionKey);
-        if (response.getStatus().equals("FAIL")) {
-            return PaymentInfo.Callback.from("FAIL", response.getReason());
+        if (response.getStatus().equals(PaymentResult.FAIL)) {
+            return PaymentInfo.Callback.from(PaymentResult.FAIL, response.getReason());
         }
-        return PaymentInfo.Callback.from("SUCCESS", null);
+        return PaymentInfo.Callback.from(PaymentResult.SUCCESS, null);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayService.java
@@ -8,7 +8,7 @@ import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
-import com.loopers.domain.payment.dto.PaymentResult;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
@@ -34,17 +34,12 @@ public class PaymentGatewayService {
     @CircuitBreaker(name = "pgCircuit", fallbackMethod = "fallback")
     @Retry(name = "pgRetry", fallbackMethod = "fallback")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void process(PaymentRequest request) {
-        Payment payment = paymentService.getDetail(request.getPaymentId());
-
-        // 결제 API 호출
-        PaymentResponse response = paymentGateway.requestPayment(request, callbackUrl);
-        if (response.getStatus().equals(PaymentResult.SUCCESS)) {
-            payment.setPaymentPending(response.getTransactionKey());
-        }
+    public PaymentResponse requestPayment(PaymentRequest request) {
+        return paymentGateway.requestPayment(request, callbackUrl);
     }
 
-    public void fallback(PaymentRequest request, Throwable throwable) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PaymentResponse fallback(PaymentRequest request, Throwable throwable) {
         Payment payment = paymentService.getDetail(request.getPaymentId());
         Order order = orderService.getDetail(payment.getOrderId());
 
@@ -53,13 +48,15 @@ public class PaymentGatewayService {
         paymentRestoreService.restore(order);
 
         log.error("결제 요청 실패 fallback: orderId={} paymentId={} message={}", order.getId(), payment.getId(), throwable.getLocalizedMessage());
+
+        return PaymentResponse.fail("결제에 실패했습니다." + throwable.getLocalizedMessage());
     }
 
     public PaymentInfo.Callback getTransaction(String transactionKey) {
         PaymentResponse response = paymentGateway.getTransaction(transactionKey);
-        if (response.getStatus().equals(PaymentResult.FAIL)) {
-            return PaymentInfo.Callback.from(PaymentResult.FAIL, response.getReason());
+        if (response.getStatus().equals(PaymentResponseResult.FAIL)) {
+            return PaymentInfo.Callback.from(PaymentResponseResult.FAIL, response.getReason());
         }
-        return PaymentInfo.Callback.from(PaymentResult.SUCCESS, null);
+        return PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,8 +1,0 @@
-package com.loopers.application.payment;
-
-import com.loopers.domain.payment.dto.PaymentRequest;
-import com.loopers.domain.payment.dto.PaymentResponse;
-
-public interface PaymentProcessor {
-    PaymentResponse process(PaymentRequest request);
-}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRestoreService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRestoreService.java
@@ -1,6 +1,6 @@
 package com.loopers.application.payment;
 
-import com.loopers.application.order.PointProcessor;
+import com.loopers.application.order.PointUseService;
 import com.loopers.application.order.StockService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
@@ -15,7 +15,7 @@ public class PaymentRestoreService {
 
     private final UserCouponService userCouponService;
     private final StockService stockService;
-    private final PointProcessor pointProcessor;
+    private final PointUseService pointUseService;
 
     public void restore(Order order) {
         // 쿠폰 원복
@@ -28,6 +28,6 @@ public class PaymentRestoreService {
         }
 
         // 포인트 원복
-        pointProcessor.restoreWithLock(order.getUserId(), order.getPointAmount(), order.getId());
+        pointUseService.restoreWithLock(order.getUserId(), order.getPointAmount(), order.getId());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
@@ -29,20 +29,19 @@ public class PaymentRetryService {
 
             PaymentResponse response = paymentGateway.getTransaction(payment.getTransactionKey());
 
-            String status = response.getStatus();
-            switch (status) {
-                case "SUCCESS":
-                    payment.setPaymentSuccess(status);
+            switch (response.getStatus()) {
+                case SUCCESS:
+                    payment.setPaymentSuccess(response.getReason());
                     order.markPaid();
                     log.info("결제 성공: orderId={} paymentId={}", order.getId(), payment.getId());
                     break;
-                case "FAIL":
-                    payment.setPaymentFailed(status);
+                case FAIL:
+                    payment.setPaymentFailed(response.getReason());
                     order.markPaymentFailed();
                     paymentRestoreService.restore(order);
                     log.info("결제 실패: orderId={} paymentId={}", order.getId(), payment.getId());
                     break;
-                case "PENDING":
+                case PENDING:
                     if (payment.getCreatedAt().isBefore(ZonedDateTime.now().minusMinutes(30))) {
                         payment.setPaymentFailed("결제가 지연되어 취소되었습니다.");
                         order.markPaymentFailed();

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentRetryService.java
@@ -3,6 +3,7 @@ package com.loopers.application.payment;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.dto.PaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
@@ -5,11 +5,8 @@ import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.dto.CardType;
 import com.loopers.domain.payment.dto.PaymentRequest;
-import com.loopers.domain.payment.dto.PaymentResult;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentCommand {
@@ -42,7 +39,7 @@ public class PaymentCommand {
     public static class Callback {
         private String orderNo;
         private String transactionKey;
-        private PaymentResult result;
+        private PaymentResponseResult result;
         private String reason;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
@@ -2,8 +2,10 @@ package com.loopers.application.payment.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.dto.CardType;
 import com.loopers.domain.payment.dto.PaymentRequest;
+import com.loopers.domain.payment.dto.PaymentResult;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +19,7 @@ public class PaymentCommand {
     public static class Create {
         private Long userId;
         private Long orderId;
+        private PaymentMethod method;
         private CardType cardType;
         private String cardNo;
         private int paymentAmount;
@@ -25,7 +28,7 @@ public class PaymentCommand {
             return PaymentRequest.create(
                     order.getOrderNo().toString(),
                     payment.getId(),
-                    payment.getMethod(),
+                    method,
                     cardType,
                     cardNo,
                     paymentAmount,
@@ -36,10 +39,10 @@ public class PaymentCommand {
 
     @Getter
     @Builder
-    public static class Modify {
+    public static class Callback {
         private String orderNo;
         private String transactionKey;
-        private String status;
+        private PaymentResult result;
         private String reason;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment;
+package com.loopers.application.payment.dto;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.payment.Payment;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
@@ -2,7 +2,7 @@ package com.loopers.application.payment.dto;
 
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentStatus;
-import com.loopers.domain.payment.dto.PaymentResult;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,10 +34,10 @@ public class PaymentInfo {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Callback {
-        private PaymentResult result;
+        private PaymentResponseResult result;
         private String message;
 
-        public static PaymentInfo.Callback from(PaymentResult result, String message) {
+        public static PaymentInfo.Callback from(PaymentResponseResult result, String message) {
             return new PaymentInfo.Callback(result, message);
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment;
+package com.loopers.application.payment.dto;
 
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentStatus;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentInfo.java
@@ -2,6 +2,7 @@ package com.loopers.application.payment.dto;
 
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.PaymentResult;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,11 +34,11 @@ public class PaymentInfo {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Callback {
-        private String result;
+        private PaymentResult result;
         private String message;
 
-        public static Callback from(String result, String message) {
-            return new Callback(result, message);
+        public static PaymentInfo.Callback from(PaymentResult result, String message) {
+            return new PaymentInfo.Callback(result, message);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -46,16 +46,16 @@ public class OrderService {
 
     public void checkInitOrder(Order order, Long userId) {
         if (!order.getUserId().equals(userId)) {
-            throw new IllegalStateException("사용자 정보가 일치하지 않습니다.");
+            throw new CoreException(ErrorType.CONFLICT, "사용자 정보가 일치하지 않습니다.");
         }
         if (order.getStatus() != OrderStatus.CREATED) {
-            throw new IllegalStateException("주문 상태가 대기중이 아닙니다. status: " + order.getStatus());
+            throw new CoreException(ErrorType.CONFLICT, "주문 상태가 대기중이 아닙니다. status: " + order.getStatus());
         }
     }
 
     public void checkWaitingOrder(Order order) {
         if (order.getStatus() != OrderStatus.WAITING_PAYMENT) {
-            throw new IllegalStateException("주문 상태가 결제 대기중이 아닙니다. status: " + order.getStatus());
+            throw new CoreException(ErrorType.CONFLICT, "주문 상태가 결제 대기중이 아닙니다. status: " + order.getStatus());
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment;
+package com.loopers.domain.payment;
 
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
@@ -11,6 +11,5 @@ public interface PaymentGateway {
 
     PaymentResponse getTransaction(String transactionKey);
 
-    List<PaymentResponse> getTransactionsByOrder(String orderId);
-
+    List<PaymentResponse> getTransactionsByOrder(String orderNo);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -56,7 +56,7 @@ public class PaymentService {
         if (!checkPayment.getTransactionKey().equals(payment.getTransactionKey())) {
             throw new IllegalStateException("Transaction Key가 일치하지 않습니다.");
         }
-        if (payment.getStatus() == PaymentStatus.PENDING) {
+        if (payment.getStatus() != PaymentStatus.PENDING) {
             throw new IllegalStateException("결제 상태가 대기중이 아닙니다. status: " + payment.getStatus());
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PaymentResponse {
     private String transactionKey;
     private String orderNo;
-    private PaymentResult status;
+    private PaymentResponseResult status;
     private String reason;
 
     public static PaymentResponse from(PgClientDto.PgResponse response) {
@@ -33,7 +33,7 @@ public class PaymentResponse {
     }
 
     public static PaymentResponse fail(String reason) {
-        return new PaymentResponse(null, null, PaymentResult.FAIL, reason);
+        return new PaymentResponse(null, null, PaymentResponseResult.FAIL, reason);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PaymentResponse {
     private String transactionKey;
     private String orderNo;
-    private String status;
+    private PaymentResult status;
     private String reason;
 
     public static PaymentResponse from(PgClientDto.PgResponse response) {
@@ -33,7 +33,7 @@ public class PaymentResponse {
     }
 
     public static PaymentResponse fail(String reason) {
-        return new PaymentResponse(null, null, "FAIL", reason);
+        return new PaymentResponse(null, null, PaymentResult.FAIL, reason);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponseResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResponseResult.java
@@ -1,5 +1,5 @@
 package com.loopers.domain.payment.dto;
 
-public enum PaymentResult {
+public enum PaymentResponseResult {
     SUCCESS, FAIL, PENDING
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentResult.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.payment.dto;
+
+public enum PaymentResult {
+    SUCCESS, FAIL, PENDING
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.client.pg;
 
 import com.loopers.domain.payment.dto.PaymentRequest;
-import com.loopers.domain.payment.dto.PaymentResult;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -31,7 +31,7 @@ public class PgClientDto {
     public record PgResponse(
             String transactionKey,
             String orderId,
-            PaymentResult status,
+            PaymentResponseResult status,
             String reason
     ) { }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgClientDto.java
@@ -1,6 +1,7 @@
 package com.loopers.infrastructure.client.pg;
 
 import com.loopers.domain.payment.dto.PaymentRequest;
+import com.loopers.domain.payment.dto.PaymentResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -30,7 +31,7 @@ public class PgClientDto {
     public record PgResponse(
             String transactionKey,
             String orderId,
-            String status,
+            PaymentResult status,
             String reason
     ) { }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/client/pg/PgPaymentGateway.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.client.pg;
 
-import com.loopers.application.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.dto.PaymentRequest;
 import com.loopers.domain.payment.dto.PaymentResponse;
 import com.loopers.interfaces.api.ApiResponse;
@@ -48,8 +48,8 @@ public class PgPaymentGateway implements PaymentGateway {
     }
 
     @Override
-    public List<PaymentResponse> getTransactionsByOrder(String orderId) {
-        ApiResponse<PgClientDto.OrderResponse> apiResponse = pgClient.getTransactionsByOrder(orderId, userId);
+    public List<PaymentResponse> getTransactionsByOrder(String orderNo) {
+        ApiResponse<PgClientDto.OrderResponse> apiResponse = pgClient.getTransactionsByOrder(orderNo, userId);
         log.info("주문 전체 결제 조회 결과: {}", apiResponse.meta().result());
 
         if (apiResponse.meta().result().equals(ApiResponse.Metadata.Result.FAIL)) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentAlertSenderImpl.java
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.application.payment.PaymentAlertSender;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class PaymentAlertSenderImpl implements PaymentAlertSender {
+
+    @Value("${client.pg-simulator.x-user-id}")
+    private Long userId;
+
+    @Override
+    public void sendFail(Map<String, Object> params, Exception e) {
+        log.info("PG 결제 실패 알림 전송");
+        log.error("[PG 콜백 처리 실패]\n {}",
+                String.format(
+                        "userId=%s, transactionKey=%s\nerror=%s",
+                        userId,
+                        params.get("transactionKey"),
+                        e.getLocalizedMessage()
+                ));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.order;
 
-import com.loopers.application.order.OrderCommand;
-import com.loopers.application.order.OrderInfo;
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.order.OrderStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -58,6 +58,6 @@ public interface PaymentV1ApiSpec {
                             )
                     )
             )
-            @RequestBody PaymentV1Dto.PaymentRequest.Modify request
+            @RequestBody PaymentV1Dto.PaymentRequest.Callback request
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -25,13 +25,8 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
 
     @PostMapping("/callback")
     @Override
-    public ApiResponse<?> callback(PaymentV1Dto.PaymentRequest.Modify request) {
-        PaymentV1Dto.PaymentResponse.Callback response = PaymentV1Dto.PaymentResponse.Callback.from(paymentFacade.paymentCallback(request.toCommand()));
-        if ("SUCCESS".equalsIgnoreCase(response.result())) {
-            return ApiResponse.success(response);
-        } else {
-            String errorMessage = response.message();
-            return ApiResponse.fail("FAIL", errorMessage);
-        }
+    public ApiResponse<String> callback(PaymentV1Dto.PaymentRequest.Modify request) {
+        paymentFacade.paymentCallback(request.toCommand());
+        return ApiResponse.success("SUCCESS");
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -25,7 +25,7 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
 
     @PostMapping("/callback")
     @Override
-    public ApiResponse<String> callback(PaymentV1Dto.PaymentRequest.Modify request) {
+    public ApiResponse<String> callback(PaymentV1Dto.PaymentRequest.Callback request) {
         paymentFacade.paymentCallback(request.toCommand());
         return ApiResponse.success("SUCCESS");
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -3,7 +3,7 @@ package com.loopers.interfaces.api.payment;
 import com.loopers.application.payment.dto.PaymentCommand;
 import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.payment.dto.CardType;
-import com.loopers.domain.payment.dto.PaymentResult;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -32,7 +32,7 @@ public class PaymentV1Dto {
         public record Callback(
                 String orderNo,
                 String transactionKey,
-                PaymentResult status,
+                PaymentResponseResult status,
                 String reason
         ) {
             public PaymentCommand.Callback toCommand() {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -3,6 +3,7 @@ package com.loopers.interfaces.api.payment;
 import com.loopers.application.payment.dto.PaymentCommand;
 import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.payment.dto.CardType;
+import com.loopers.domain.payment.dto.PaymentResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -28,17 +29,17 @@ public class PaymentV1Dto {
             }
         }
 
-        public record Modify(
+        public record Callback(
                 String orderNo,
                 String transactionKey,
-                String status,
+                PaymentResult status,
                 String reason
         ) {
-            public PaymentCommand.Modify toCommand() {
-                return PaymentCommand.Modify.builder()
+            public PaymentCommand.Callback toCommand() {
+                return PaymentCommand.Callback.builder()
                         .orderNo(orderNo)
                         .transactionKey(transactionKey)
-                        .status(status)
+                        .result(status)
                         .reason(reason)
                         .build();
             }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.payment;
 
-import com.loopers.application.payment.PaymentCommand;
-import com.loopers.application.payment.PaymentInfo;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.application.payment.dto.PaymentInfo;
 import com.loopers.domain.payment.dto.CardType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -61,18 +61,6 @@ public class PaymentV1Dto {
                         info.getPaymentAmount(),
                         info.getStatus().toString(),
                         info.getTransactionKey()
-                );
-            }
-        }
-
-        public record Callback(
-                String result,
-                String message
-        ) {
-            public static PaymentResponse.Callback from(PaymentInfo.Callback main) {
-                return new PaymentResponse.Callback(
-                        main.getResult(),
-                        main.getMessage()
                 );
             }
         }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -7,7 +7,6 @@ import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import com.loopers.domain.order.OrderStatus;
-import com.loopers.domain.payment.Payment;
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointHistory;
 import com.loopers.domain.point.PointType;
@@ -17,7 +16,6 @@ import com.loopers.domain.userCoupon.UserCoupon;
 import com.loopers.infrastructure.brand.BrandJpaRepository;
 import com.loopers.infrastructure.coupon.CouponJpaRepository;
 import com.loopers.infrastructure.order.OrderJpaRepository;
-import com.loopers.infrastructure.payment.PaymentJpaRepository;
 import com.loopers.infrastructure.point.PointHistoryJpaRepository;
 import com.loopers.infrastructure.point.PointJpaRepository;
 import com.loopers.infrastructure.product.ProductJpaRepository;
@@ -53,8 +51,6 @@ class OrderFacadeIntegrationTest {
     @Autowired
     private PointHistoryJpaRepository pointHistoryJpaRepository;
     @Autowired
-    private PaymentJpaRepository paymentJpaRepository;
-    @Autowired
     private CouponJpaRepository couponJpaRepository;
     @Autowired
     private UserCouponJpaRepository userCouponJpaRepository;
@@ -82,15 +78,15 @@ class OrderFacadeIntegrationTest {
 
             @DisplayName("정상적인 파라미터가 주어진 경우")
             @Test
-            void whenValidParameter() {
+            void whenValidParameter_thenOrderCreated() {
                 // arrange
-                final int initQuantity = 10;
-                final int decreaseQuantity = 2;
-                final int initPoint = 50000;
-                final int usePoint = 10000;
-                final int price = 20000;
-                final int discountAmount = 3000;
-                final int totalAmount = (decreaseQuantity * price) - discountAmount - usePoint;
+                int initQuantity = 10;
+                int decreaseQuantity = 2;
+                int initPoint = 50000;
+                int usePoint = 10000;
+                int price = 20000;
+                int discountAmount = 3000;
+                int totalAmount = (decreaseQuantity * price) - discountAmount - usePoint;
 
                 Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
                 Product product = productJpaRepository.save(Product.createBuilder().name("상품").price(price).brand(brand).build());
@@ -120,75 +116,38 @@ class OrderFacadeIntegrationTest {
                 assertThat(order.getPointAmount()).isEqualTo(usePoint);
 
                 Stock stock = stockJpaRepository.findByProductId(product.getId()).get();
-                assertThat(stock.getQuantity()).isEqualTo(initQuantity-decreaseQuantity);
+                assertThat(stock.getQuantity()).isEqualTo(initQuantity - decreaseQuantity);
 
                 Point point = pointJpaRepository.findByUserId(userId).get();
-                assertThat(point.getPoint()).isEqualTo(initPoint-usePoint);
+                assertThat(point.getPoint()).isEqualTo(initPoint - usePoint);
 
                 List<PointHistory> histories = pointHistoryJpaRepository.findByUserId(userId);
                 assertThat(histories).hasSize(1);
                 assertThat(histories.get(0).getType()).isEqualTo(PointType.USE);
-
-                List<Payment> payments = paymentJpaRepository.findAll();
-                assertThat(payments).hasSize(1);
-                assertThat(payments.get(0).getPaymentAmount()).isEqualTo(totalAmount);
-                assertThat(payments.get(0).getUserId()).isEqualTo(userId);
             }
         }
 
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         @Nested
-        class 주문_생성이_실패하고_404_Not_Found_예외가_발생한다 {
+        class 주문_생성이_실패하고_데이터가_원복된다 {
 
-            @DisplayName("사용 불가능하거나 존재하지 않는 쿠폰이라면")
+            @DisplayName("재고 부족으로 예외가 발생한 경우")
             @Test
-            void whenInvalidCoupon() {
+            void whenStockNotEnough_thenRollbackAll() {
                 // arrange
-                final int price = 20000;
-                final int quantity = 1;
-                final int initPoint = 50000;
-                Long userCouponId = 9999L;
-
-                Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
-                Product product = productJpaRepository.save(Product.createBuilder().name("상품").price(price).brand(brand).build());
-                stockJpaRepository.save(new Stock(product, 10));
-                pointJpaRepository.save(new Point(userId, initPoint));
-
-                OrderCommand.Create command = OrderCommand.Create.builder()
-                        .userId(userId)
-                        .items(List.of(OrderCommand.Item.builder()
-                                .productId(product.getId())
-                                .quantity(quantity)
-                                .amount(price)
-                                .build()))
-                        .userCouponId(userCouponId)
-                        .build();
-
-                // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderFacade.create(command));
-
-                // assert
-                assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
-            }
-        }
-
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        @Nested
-        class 주문_생성이_실패하고_409_Conflict_예외가_발생한다 {
-
-            @DisplayName("재고가 부족하다면")
-            @Test
-            void whenStockIsNotEnough() {
-                // arrange
-                final int initQuantity = 1;
-                final int decreaseQuantity = 2;
-                final int initPoint = 50000;
-                final int price = 20000;
+                int initQuantity = 1;
+                int decreaseQuantity = 5;
+                int initPoint = 50000;
+                int usePoint = 10000;
+                int price = 20000;
+                int discountAmount = 3000;
 
                 Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
                 Product product = productJpaRepository.save(Product.createBuilder().name("상품").price(price).brand(brand).build());
                 stockJpaRepository.save(new Stock(product, initQuantity));
                 pointJpaRepository.save(new Point(userId, initPoint));
+                Coupon coupon = couponJpaRepository.save(new Coupon("3천원 할인", 100, 0, PRICE, discountAmount, null, 10000));
+                UserCoupon userCoupon = userCouponJpaRepository.save(UserCoupon.create(coupon.getId(), userId));
 
                 OrderCommand.Create command = OrderCommand.Create.builder()
                         .userId(userId)
@@ -197,47 +156,24 @@ class OrderFacadeIntegrationTest {
                                 .quantity(decreaseQuantity)
                                 .amount(product.getPrice())
                                 .build()))
-                        .userCouponId(null)
-                        .build();
-
-                // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderFacade.create(command));
-
-                // assert
-                assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
-            }
-
-            @DisplayName("포인트가 부족하다면")
-            @Test
-            void whenPointIsNotEnough() {
-                // arrange
-                final int initQuantity = 10;
-                final int decreaseQuantity = 2;
-                final int initPoint = 10000;
-                final int usePoint = 20000;
-                final int price = 20000;
-
-                Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
-                Product product = productJpaRepository.save(Product.createBuilder().name("상품").price(price).brand(brand).build());
-                stockJpaRepository.save(new Stock(product, initQuantity));
-                pointJpaRepository.save(new Point(userId, initPoint));
-
-                OrderCommand.Create command = OrderCommand.Create.builder()
-                        .userId(userId)
-                        .items(List.of(OrderCommand.Item.builder()
-                                .productId(product.getId())
-                                .quantity(decreaseQuantity)
-                                .amount(product.getPrice())
-                                .build()))
-                        .userCouponId(null)
+                        .userCouponId(userCoupon.getId())
                         .point(usePoint)
                         .build();
 
+                int beforeStock = stockJpaRepository.findByProductId(product.getId()).get().getQuantity();
+                int beforePoint = pointJpaRepository.findByUserId(userId).get().getPoint();
+                boolean beforeCouponUsed = userCouponJpaRepository.findById(coupon.getId()).get().isUsed();
+
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderFacade.create(command));
+                orderFacade.create(command);
 
                 // assert
-                assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+                Order order = orderJpaRepository.findAll().get(0);
+                assertThat(order.getStatus()).isEqualTo(OrderStatus.ORDER_FAILED);
+
+                assertThat(stockJpaRepository.findByProductId(product.getId()).get().getQuantity()).isEqualTo(beforeStock);
+                assertThat(pointJpaRepository.findByUserId(userId).get().getPoint()).isEqualTo(beforePoint);
+                assertThat(userCouponJpaRepository.findById(userCoupon.getId()).get().isUsed()).isEqualTo(beforeCouponUsed);
             }
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.application.order.dto.OrderInfo;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.order.Order;

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderValidationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderValidationServiceTest.java
@@ -1,0 +1,179 @@
+package com.loopers.application.order;
+
+import com.loopers.application.order.dto.OrderCommand;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderValidationServiceTest {
+
+    @Mock
+    private CouponUseService couponUseService;
+    @Mock
+    private StockService stockService;
+    @Mock
+    private PointUseService pointUseService;
+
+    @InjectMocks
+    private OrderValidationService orderValidationService;
+
+    @DisplayName("쿠폰/재고/포인트가 정상적으로 차사감되면 주문 엔티티에 반영된다.")
+    @Test
+    void whenValidSuccess_thenOrderUpdated() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+
+        // act
+        orderValidationService.validate(command, order);
+
+        // assert
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verify(pointUseService).useWithLock(userId, usePoint, order.getId());
+
+        assertThat(order.getDiscountAmount()).isEqualTo(discountAmount);
+        assertThat(order.getPointAmount()).isEqualTo(usePoint);
+    }
+
+    @DisplayName("쿠폰 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenCouponUseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenThrow(new RuntimeException("쿠폰 차감 실패"));
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verifyNoInteractions(stockService);
+        verifyNoInteractions(pointUseService);
+    }
+
+    @DisplayName("재고 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenStockDecreaseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+        doThrow(new RuntimeException("재고 차감 실패")).when(stockService).decrease(anyLong(), anyInt());
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verifyNoInteractions(pointUseService);
+    }
+
+    @DisplayName("포인트 차감 중 예외가 발생하면 변경값이 반영되지 않는다.")
+    @Test
+    void whenPointUseFails_thenExceptionThrown() {
+        // arrange
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productId = 1L;
+        int quantity = 2;
+        int amount = 5000;
+        int discountAmount = 3000;
+        int usePoint = 1000;
+
+        OrderItem item = OrderItem.of(productId, quantity, amount);
+        Order order = Order.create(userId, userCouponId, List.of(item));
+
+        OrderCommand.Create command = OrderCommand.Create.builder()
+                .userId(userId)
+                .userCouponId(userCouponId)
+                .point(usePoint)
+                .items(List.of(OrderCommand.Item.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .amount(amount)
+                        .build()))
+                .build();
+
+        when(couponUseService.use(anyLong(), anyLong(), anyInt())).thenReturn(discountAmount);
+        doThrow(new RuntimeException("포인트 차감 실패")).when(pointUseService).useWithLock(anyLong(), anyInt(), anyLong());
+
+        // act & assert
+        assertThrows(RuntimeException.class, () -> orderValidationService.validate(command, order));
+        verify(couponUseService).use(userCouponId, userId, order.getTotalAmount());
+        verify(stockService).decrease(productId, quantity);
+        verify(pointUseService).useWithLock(userId, usePoint, order.getId());
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/PointUseServiceConcurrencyTest.java
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("포인트 사용에 락 적용 시")
 @SpringBootTest
-class PointProcessorConcurrencyTest {
+class PointUseServiceConcurrencyTest {
     // sut --
     @Autowired
-    private PointProcessor pointProcessor;
+    private PointUseService pointUseService;
 
     // orm--
     @Autowired
@@ -64,7 +64,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -109,7 +109,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -162,7 +162,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.use(1L, usePoint, 1L);
+                        pointUseService.use(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -220,7 +220,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -272,7 +272,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());
@@ -325,7 +325,7 @@ class PointProcessorConcurrencyTest {
             for (int i = 0; i < requestCount; i++) {
                 executor.submit(() -> {
                     try {
-                        pointProcessor.useWithLock(1L, usePoint, 1L);
+                        pointUseService.useWithLock(1L, usePoint, 1L);
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         System.out.println("[FAIL]: "+e.getMessage());

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadeIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.order.ExternalOrderSender;
+import com.loopers.application.payment.dto.PaymentCommand;
+import com.loopers.application.payment.dto.PaymentInfo;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.CardType;
+import com.loopers.domain.payment.dto.PaymentRequest;
+import com.loopers.domain.payment.dto.PaymentResponse;
+import com.loopers.domain.payment.dto.PaymentResponseResult;
+import com.loopers.infrastructure.client.pg.PgClientDto;
+import com.loopers.infrastructure.order.OrderJpaRepository;
+import com.loopers.infrastructure.payment.PaymentJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class PaymentFacadeIntegrationTest {
+
+    // orm --
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+    @Autowired
+    private PaymentJpaRepository paymentJpaRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    // sut--
+    @Autowired
+    private PaymentFacade paymentFacade;
+
+    @MockitoBean
+    private PaymentGatewayService paymentGatewayService;
+    @MockitoBean
+    private PaymentRestoreService paymentRestoreService;
+    @MockitoBean
+    private ExternalOrderSender externalOrderSender;
+    @MockitoBean
+    private PaymentAlertSender paymentAlertSender;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    final Long userId = 1L;
+    Order order;
+    Payment payment;
+
+    @BeforeEach
+    void setUp() {
+        OrderItem item = OrderItem.of(1L, 1, 10000);
+        order = orderJpaRepository.save(Order.create(userId, 1L, List.of(item)));
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 결제_요청_시 {
+        PaymentCommand.Create command;
+
+        @BeforeEach
+        void setUp() {
+            payment = Payment.createBuilder().userId(userId).paymentAmount(order.getTotalAmount()).build();
+            command = PaymentCommand.Create.builder()
+                    .userId(userId)
+                    .orderId(order.getId())
+                    .method(PaymentMethod.CARD)
+                    .cardType(CardType.SAMSUNG)
+                    .cardNo("1111-2222-3333-4444")
+                    .paymentAmount(order.getTotalAmount())
+                    .build();
+        }
+
+        @DisplayName("PG 결제가 성공하면 Payment 는 PENDING 상태가 된다.")
+        @Test
+        void whenPgSuccess_thenPaymentPending() {
+            // arrange
+            PgClientDto.PgResponse pgResponse = new PgClientDto.PgResponse(
+                    "TR:9577c5",
+                    order.getOrderNo().toString(),
+                    PaymentResponseResult.SUCCESS,
+                    "요청 완료"
+            );
+            PaymentResponse response = PaymentResponse.from(pgResponse);
+
+            when(paymentGatewayService.requestPayment(any(PaymentRequest.class)))
+                    .thenReturn(response);
+
+            // act
+            PaymentInfo.Main result = paymentFacade.payment(command);
+
+            // assert
+            Payment payment = paymentJpaRepository.findById(result.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+            assertThat(payment.getTransactionKey()).isEqualTo(pgResponse.transactionKey());
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.WAITING_PAYMENT);
+
+            verify(paymentGatewayService).requestPayment(any(PaymentRequest.class));
+        }
+
+        @Test
+        @DisplayName("주문 상태가 CREATED 가 아닌 경우 결제요청은 실패한다.")
+        void whenOrderStatusIsNotCreated_thenFail() {
+            // arrange
+            order.markWaitingPayment();
+            orderJpaRepository.save(order);
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> paymentFacade.payment(command));
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+
+    @Nested
+    class 결제_콜백_시 {
+        String transactionKey = "TR:9577c5";
+
+        @BeforeEach
+        void setUp() {
+            order.markWaitingPayment();
+            orderJpaRepository.save(order);
+            payment = Payment.createBuilder()
+                    .userId(userId)
+                    .orderId(order.getId())
+                    .paymentAmount(order.getTotalAmount())
+                    .method(PaymentMethod.CARD)
+                    .build();
+            payment.setPaymentPending(transactionKey);
+            paymentJpaRepository.save(payment);
+        }
+
+        @DisplayName("PG 콜백이 SUCCESS 인 경우, Payment와 Order는 결제대기 상태로 바뀌고 외부 전송이 호출된다.")
+        @Test
+        void whenCallbackSuccess_thenPaymentAndOrderSuccess() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.SUCCESS)
+                    .reason("승인 완료")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenReturn(PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            Payment updatedPayment = paymentJpaRepository.findById(payment.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(updatedPayment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.PAID);
+
+            verify(externalOrderSender).send(any(Order.class));
+        }
+
+        @Test
+        @DisplayName("PG 콜백이 FAIL 인 경우, Payment와 Order는 실패 상태로 바뀌고 원복 로직이 실행된다.")
+        void whenCallbackFail_thenPaymentAndOrderFailed() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.FAIL)
+                    .reason("한도 초과")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenReturn(PaymentInfo.Callback.from(PaymentResponseResult.SUCCESS, null));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            Payment updatedPayment = paymentJpaRepository.findById(payment.getId()).get();
+            Order updatedOrder = orderJpaRepository.findById(order.getId()).get();
+
+            assertThat(updatedPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+            assertThat(updatedOrder.getStatus()).isEqualTo(OrderStatus.PAYMENT_FAILED);
+
+            verify(paymentRestoreService).restore(any(Order.class));
+        }
+
+        @Test
+        @DisplayName("PG 조회에서 예외가 발생하는 경우, 알림이 전송된다.")
+        void whenExceptionOccur_thenAlertSend() {
+            // arrange
+            PaymentCommand.Callback command = PaymentCommand.Callback.builder()
+                    .orderNo(order.getOrderNo().toString())
+                    .transactionKey(transactionKey)
+                    .result(PaymentResponseResult.SUCCESS)
+                    .reason("승인 완료")
+                    .build();
+
+            when(paymentGatewayService.getTransaction(transactionKey))
+                    .thenThrow(new RuntimeException("PG 서버 오류"));
+
+            // act
+            paymentFacade.paymentCallback(command);
+
+            // assert
+            verify(paymentAlertSender).sendFail(anyMap(), any(RuntimeException.class));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- PG 연동 흐름 리팩토링
  - PaymentProcessor 제거, PaymentGatewayService 추가
  - PG callback 실패 시 알림 전송, callback API 응답 항상 200 OK 반환
  - PaymentResult → PaymentResponseResult 리네이밍 및 enum 추가

- 결제 로직 개선
  - PG 결제 요청 이후 처리 로직을 PaymentFacade로 이동
  - requestPayment 반환 값 확장 (응답 결과 포함)

- 주문 트랜잭션 개선
  - OrderFacade.create 검증 로직을 별도 트랜잭션(OrderValidationService)으로 분리
  - 예외 발생 시 주문 상태 및 리소스 원복 처리 보장
  - OrderValidationService 단위(Mock) 테스트 추가

- 리팩토링 및 버그 수정
  - OrderService 예외 타입 변경 (IllegalStateException → CoreException)
  - OrderProcessor → OrderValidationService, PointProcessor → PointUseService 클래스명 변경
  - PaymentService.checkPendingPayment 오류 수정