### PR TITLE
[volume-9] commerce-api 모듈 내 상품 랭킹 조회 API 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
@@ -1,0 +1,24 @@
+package com.loopers.application.ranking;
+
+import lombok.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingCommand {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Summary {
+
+        private String date;
+        @Builder.Default private int page = 0;
+        @Builder.Default private int size = 20;
+
+        public Pageable toPageable() {
+            return PageRequest.of(page, size);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,56 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingFacade {
+
+    private final RankingService rankingService;
+    private final ProductService productService;
+    private final BrandService brandService;
+
+    @Transactional(readOnly = true)
+    public RankingInfo.Summary getList(RankingCommand.Summary command) {
+        String key = rankingService.buildRankingKey(command.getDate());
+        Pageable pageable = command.toPageable();
+
+        if (!rankingService.existsRankingKey(key)) {
+            log.warn("Ranking key not found: {}", key);
+            return RankingInfo.Summary.empty(pageable);
+        }
+
+        return getFromRedis(key, pageable);
+    }
+
+    private RankingInfo.Summary getFromRedis(String key, Pageable pageable) {
+        List<RankingRaw> raws = rankingService.getTopRankings(key, pageable);
+        long totalCount = rankingService.getTotalRankingCount(key);
+
+        if (raws.isEmpty()) {
+            return RankingInfo.Summary.empty(pageable);
+        }
+
+        List<Long> productIds = raws.stream().map(RankingRaw::productId).toList();
+        List<Product> products = productService.getListByIds(productIds);
+        if (products.isEmpty()) {
+            return RankingInfo.Summary.empty(pageable);
+        }
+
+        List<Long> brandIds = products.stream().map(p -> p.getBrand().getId()).distinct().toList();
+        List<Brand> brands = brandService.getListByIds(brandIds);
+
+        return RankingInfo.Summary.from(raws, products, brands, pageable, totalCount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
@@ -1,0 +1,86 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingInfo {
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Item {
+        private int rank;
+        private Long productId;
+        private String productName;
+        private int price;
+        private String brandName;
+        private double score;
+
+        public static RankingInfo.Item from(int rank, Product product, Brand brand, double score) {
+            return new RankingInfo.Item(
+                    rank,
+                    product.getId(),
+                    product.getName(),
+                    product.getPrice(),
+                    brand.getName(),
+                    score
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Summary {
+        private List<Item> rankings;
+        private int page;
+        private int size;
+        private long totalCount;
+
+        public static RankingInfo.Summary from(
+                List<RankingRaw> raws,
+                List<Product> products,
+                List<Brand> brands,
+                Pageable pageable,
+                long totalCount
+        ) {
+
+            Map<Long, Product> productMap = products.stream()
+                    .collect(Collectors.toMap(Product::getId, Function.identity()));
+            Map<Long, Brand> brandMap = brands.stream()
+                    .collect(Collectors.toMap(Brand::getId, Function.identity()));
+
+            List<Item> items = IntStream.range(0, raws.size())
+                    .mapToObj(i -> {
+                        RankingRaw raw = raws.get(i);
+                        Product product = productMap.get(raw.productId());
+                        if (product == null) return null;
+
+                        Brand brand = brandMap.get(product.getBrand().getId());
+                        if (brand == null) return null;
+
+                        int rank = (int) pageable.getOffset() + i + 1;
+                        return Item.from(rank, product, brand, raw.score());
+                    })
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            return new RankingInfo.Summary(items, pageable.getPageNumber(), pageable.getPageSize(), totalCount);
+        }
+
+        public static RankingInfo.Summary empty(Pageable pageable) {
+            return new RankingInfo.Summary(List.of(), pageable.getPageNumber(), pageable.getPageSize(), 0);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingRaw.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingRaw.java
@@ -1,0 +1,6 @@
+package com.loopers.application.ranking;
+
+public record RankingRaw(
+        Long productId,
+        double score
+) { }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,0 +1,64 @@
+package com.loopers.application.ranking;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Set;
+
+import static com.loopers.redis.config.CacheConstants.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(RANKING_DATE_PATTERN);
+
+    public List<RankingRaw> getTopRankings(String key, Pageable pageable) {
+        Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(key, pageable.getOffset(), pageable.getOffset() + pageable.getPageSize() - 1);
+        if (tuples == null) return List.of();
+
+        return tuples.stream()
+                .map(tuple -> new RankingRaw(
+                        tuple.getValue() == null ? null : Long.parseLong(tuple.getValue().substring(RANKING_PRODUCT_CACHE_MEMBER_KEY.length())),
+                        tuple.getScore() == null ? 0.0 : tuple.getScore()
+                ))
+                .toList();
+    }
+
+    public long getTotalRankingCount(String rankingKey) {
+        Long count = redisTemplate.opsForZSet().zCard(rankingKey);
+        return count != null ? count : 0;
+    }
+
+    public boolean existsRankingKey(String rankingKey) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(rankingKey));
+    }
+
+    public String buildRankingKey(String date) {
+        try {
+            LocalDate parsedDate = LocalDate.parse(date, FORMATTER);
+            return buildRankingKey(parsedDate);
+        } catch (DateTimeParseException e) {
+            log.error("Error parsing date: {}", date);
+            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 날짜 형식입니다.");
+        }
+    }
+
+    public String buildRankingKey(LocalDate date) {
+        return RANKING_PRODUCT_CACHE_KEY_PREFIX + date.format(FORMATTER);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -11,6 +11,8 @@ public interface ProductRepository {
 
     Product findById(Long id);
 
+    List<Product> findAllByIds(List<Long> ids);
+
     Page<Product> search(Long brandId, Pageable pageable, ProductSortType sortType);
 
     List<Product> findTopListByBrandId(Long brandId);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -27,6 +27,10 @@ public class ProductService {
         return productRepository.search(brandId, pageable, sortType);
     }
 
+    public List<Product> getListByIds(List<Long> productIds) {
+        return productRepository.findAllByIds(productIds);
+    }
+
     public List<Product> getTopListByBrandId(Long brandId) {
         return productRepository.findTopListByBrandId(brandId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -25,6 +25,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public List<Product> findAllByIds(List<Long> ids) {
+        return productJpaRepository.findAllById(ids);
+    }
+
+    @Override
     public Page<Product> search(Long brandId, Pageable pageable, ProductSortType sortType) {
         return productQueryDslRepository.search(brandId, pageable, sortType);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "Ranking V1 API", description = "상품 랭킹 조회 API")
+public interface RankingV1ApiSpec {
+
+    @GetMapping
+    @Operation(summary = "상품 랭킹 조회", description = "날짜, 페이징 조건으로 상품 랭킹 목록 조회")
+    ApiResponse<RankingV1Dto.RankingResponse.Summary> getList(
+            @ParameterObject
+            @Valid RankingV1Dto.RankingRequest.Summary request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rankings")
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    private final RankingFacade rankingFacade;
+
+    @GetMapping
+    @Override
+    public ApiResponse<RankingV1Dto.RankingResponse.Summary> getList(
+            @Valid RankingV1Dto.RankingRequest.Summary request
+    ) {
+        return ApiResponse.success(RankingV1Dto.RankingResponse.Summary.from(rankingFacade.getList(request.toCommand())));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,0 +1,79 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingCommand;
+import com.loopers.application.ranking.RankingInfo;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+import java.util.List;
+
+import static com.loopers.support.utils.Validation.Message.MESSAGE_PAGINATION_PAGE;
+import static com.loopers.support.utils.Validation.Message.MESSAGE_PAGINATION_SIZE;
+
+public class RankingV1Dto {
+
+    public static class RankingRequest {
+
+        public record Summary(
+                @Pattern(regexp = "\\d{8}", message = "날짜는 yyyyMMdd 형식이어야 합니다.")
+                String date,
+                @Min(value = 0, message = MESSAGE_PAGINATION_PAGE)
+                int page,
+                @Min(value = 10, message = MESSAGE_PAGINATION_SIZE)
+                @Max(value = 50, message = MESSAGE_PAGINATION_SIZE)
+                int size
+        ) {
+            public RankingCommand.Summary toCommand() {
+                return RankingCommand.Summary.builder()
+                        .date(date)
+                        .page(page)
+                        .size(size)
+                        .build();
+            }
+        }
+    }
+
+    public static class RankingResponse {
+
+        public record Summary(
+                List<Item> rankings,
+                int page,
+                int size,
+                long totalCount
+        ) {
+            public static RankingResponse.Summary from(RankingInfo.Summary info) {
+                List<Item> rankings = info.getRankings().stream()
+                        .map(Item::from)
+                        .toList();
+
+                return new RankingResponse.Summary(
+                        rankings,
+                        info.getPage(),
+                        info.getSize(),
+                        info.getTotalCount()
+                );
+            }
+        }
+
+        public record Item(
+                int rank,
+                Long productId,
+                String productName,
+                int price,
+                String brandName,
+                double score
+        ) {
+            public static RankingResponse.Item from(RankingInfo.Item item) {
+                return new RankingResponse.Item(
+                        item.getRank(),
+                        item.getProductId(),
+                        item.getProductName(),
+                        item.getPrice(),
+                        item.getBrandName(),
+                        item.getScore()
+                );
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
@@ -1,0 +1,151 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import com.loopers.infrastructure.brand.BrandJpaRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.List;
+
+import static com.loopers.redis.config.CacheConstants.RANKING_PRODUCT_CACHE_KEY_PREFIX;
+import static com.loopers.redis.config.CacheConstants.RANKING_PRODUCT_CACHE_MEMBER_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingFacadeIntegrationTest {
+
+    // sut --
+    @Autowired
+    private RankingFacade rankingFacade;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    // orm --
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+    @Autowired
+    private BrandJpaRepository brandJpaRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 랭킹_목록_조회_시 {
+
+        @DisplayName("정상적으로 랭킹 목록을 조회한다.")
+        @Test
+        void returnRankingList() {
+            // arrange
+            String date = "20250911";
+            String key = RANKING_PRODUCT_CACHE_KEY_PREFIX + date;
+
+            Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
+            Product product1 = productJpaRepository.save(Product.createBuilder().brand(brand).name("상품1").price(10000).build());
+            Product product2 = productJpaRepository.save(Product.createBuilder().brand(brand).name("상품2").price(20000).build());
+            Product product3 = productJpaRepository.save(Product.createBuilder().brand(brand).name("상품3").price(30000).build());
+            double score1 = 99.9;
+            double score2 = 88.8;
+            double score3 = 77.7;
+
+            redisTemplate.opsForZSet().add(key, RANKING_PRODUCT_CACHE_MEMBER_KEY + product1.getId(), score1);
+            redisTemplate.opsForZSet().add(key, RANKING_PRODUCT_CACHE_MEMBER_KEY + product2.getId(), score2);
+            redisTemplate.opsForZSet().add(key, RANKING_PRODUCT_CACHE_MEMBER_KEY + product3.getId(), score3);
+
+            RankingCommand.Summary command = RankingCommand.Summary.builder().date(date).page(0).size(5).build();
+
+            // act
+            RankingInfo.Summary result = rankingFacade.getList(command);
+
+            // assert
+            assertThat(result.getRankings()).hasSize(3);
+            assertThat(result.getTotalCount()).isEqualTo(3);
+
+            List<RankingInfo.Item> rankings = result.getRankings();
+            assertThat(rankings.get(0).getScore()).isEqualTo(score1);
+            assertThat(rankings.get(0).getRank()).isEqualTo(1);
+            assertThat(rankings.get(0).getProductName()).isEqualTo(product1.getName());
+            assertThat(rankings.get(0).getBrandName()).isEqualTo(product1.getBrand().getName());
+        }
+
+        @DisplayName("랭킹 키가 존재하지 않으면 빈 결과를 반환한다.")
+        @Test
+        void returnEmpty_whenKeyNotExists() {
+            // arrange
+            RankingCommand.Summary command = RankingCommand.Summary.builder().date("20250910").page(0).size(5).build();
+
+            // act
+            RankingInfo.Summary result = rankingFacade.getList(command);
+
+            // assert
+            assertThat(result.getRankings()).isEmpty();
+            assertThat(result.getTotalCount()).isEqualTo(0);
+        }
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 페이징_처리_시 {
+
+        @DisplayName("페이징이 정상적으로 작동한다.")
+        @Test
+        void handlePaging() {
+            // arrange
+            String date = "20250912";
+            String key = RANKING_PRODUCT_CACHE_KEY_PREFIX + date;
+
+            int page = 1; // 2페이지
+            int size = 3;
+            int totalCount = 10;
+
+            int rank1 = 4;
+            int rank2 = 5;
+            int rank3 = 6;
+            double score1 = 0;
+            double score2 = 0;
+            double score3 = 0;
+
+            Brand brand = brandJpaRepository.save(Brand.builder().name("브랜드").description("설명").build());
+            for (int i = 1; i <= totalCount; i++) {
+                Product product = productJpaRepository.save(Product.createBuilder().brand(brand).name("상품" + i).price(i*10000).build());
+                double score = 100.0 - i;
+                redisTemplate.opsForZSet().add(key, RANKING_PRODUCT_CACHE_MEMBER_KEY + product.getId(), score);
+                if (i == rank1) score1 = score;
+                if (i == rank2) score2 = score;
+                if (i == rank3) score3 = score;
+            }
+
+            RankingCommand.Summary command = RankingCommand.Summary.builder().date(date).page(page).size(size).build();
+
+            // act
+            RankingInfo.Summary result = rankingFacade.getList(command);
+
+            // assert
+            assertThat(result.getRankings()).hasSize(size);
+            assertThat(result.getTotalCount()).isEqualTo(totalCount);
+
+            List<RankingInfo.Item> rankings = result.getRankings();
+
+            assertThat(rankings.get(0).getRank()).isEqualTo(rank1);
+            assertThat(rankings.get(1).getRank()).isEqualTo(rank2);
+            assertThat(rankings.get(2).getRank()).isEqualTo(rank3);
+
+            assertThat(rankings.get(0).getScore()).isEqualTo(score1);
+            assertThat(rankings.get(1).getScore()).isEqualTo(score2);
+            assertThat(rankings.get(2).getScore()).isEqualTo(score3);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingServiceTest.java
@@ -1,0 +1,199 @@
+package com.loopers.application.ranking;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.loopers.redis.config.CacheConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RankingServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 랭킹_조회_시 {
+
+        private final String key = RANKING_PRODUCT_CACHE_KEY_PREFIX + "20250911";
+
+        @BeforeEach
+        void setUp() {
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+        }
+
+        @DisplayName("정상적으로 랭킹 데이터를 반환한다.")
+        @Test
+        void returnRankingData() {
+            // arrange
+            Long productId1 = 1L;
+            Long productId2 = 2L;
+            double score1 = 99.9;
+            double score2 = 88.8;
+
+            Pageable pageable = PageRequest.of(0, 5);
+            
+            ZSetOperations.TypedTuple<String> tuple1 = mock(ZSetOperations.TypedTuple.class);
+            ZSetOperations.TypedTuple<String> tuple2 = mock(ZSetOperations.TypedTuple.class);
+            given(tuple1.getValue()).willReturn(RANKING_PRODUCT_CACHE_MEMBER_KEY + productId1);
+            given(tuple1.getScore()).willReturn(score1);
+            given(tuple2.getValue()).willReturn(RANKING_PRODUCT_CACHE_MEMBER_KEY + productId2);
+            given(tuple2.getScore()).willReturn(score2);
+            
+            Set<ZSetOperations.TypedTuple<String>> tuples = Set.of(tuple1, tuple2);
+            given(zSetOperations.reverseRangeWithScores(key, 0, 4)).willReturn(tuples);
+
+            // act
+            List<RankingRaw> result = rankingService.getTopRankings(key, pageable);
+
+            // assert
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(RankingRaw::productId).containsExactlyInAnyOrder(productId1, productId2);
+            assertThat(result).extracting(RankingRaw::score).containsExactlyInAnyOrder(score1, score2);
+        }
+
+        @DisplayName("Redis에서 null을 반환하면 빈 리스트를 반환한다.")
+        @Test
+        void returnEmptyList_whenRedisReturnsNull() {
+            // arrange
+            Pageable pageable = PageRequest.of(0, 5);
+            given(zSetOperations.reverseRangeWithScores(key, 0, 4)).willReturn(null);
+
+            // act
+            List<RankingRaw> result = rankingService.getTopRankings(key, pageable);
+
+            // assert
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 전체_랭킹_수_조회_시 {
+
+        private final String key = RANKING_PRODUCT_CACHE_KEY_PREFIX + "20250911";
+
+        @BeforeEach
+        void setUp() {
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+        }
+
+        @DisplayName("정상적으로 전체 수를 반환한다.")
+        @Test
+        void returnTotalCountSuccessfully() {
+            // arrange
+            long count = 100L;
+            given(zSetOperations.zCard(key)).willReturn(count);
+
+            // act
+            long result = rankingService.getTotalRankingCount(key);
+
+            // assert
+            assertThat(result).isEqualTo(count);
+        }
+
+        @DisplayName("Redis에서 null을 반환하면 0을 반환한다.")
+        @Test
+        void returnZeroWhenRedisReturnsNull() {
+            // arrange
+            given(zSetOperations.zCard(key)).willReturn(null);
+
+            // act
+            long result = rankingService.getTotalRankingCount(key);
+
+            // assert
+            assertThat(result).isEqualTo(0L);
+        }
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 랭킹_키_존재_여부_확인_시 {
+
+        private final String key = RANKING_PRODUCT_CACHE_KEY_PREFIX + "20250911";
+
+        @DisplayName("키가 존재하면 true를 반환한다.")
+        @Test
+        void returnTrueWhenKeyExists() {
+            // arrange
+            given(redisTemplate.hasKey(key)).willReturn(true);
+
+            // act
+            boolean result = rankingService.existsRankingKey(key);
+
+            // assert
+            assertThat(result).isTrue();
+        }
+
+        @DisplayName("키가 존재하지 않으면 false를 반환한다.")
+        @Test
+        void returnFalseWhenKeyDoesNotExist() {
+            // arrange
+            given(redisTemplate.hasKey(key)).willReturn(false);
+
+            // act
+            boolean result = rankingService.existsRankingKey(key);
+
+            // assert
+            assertThat(result).isFalse();
+        }
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @Nested
+    class 랭킹_키_생성_시 {
+
+        @DisplayName("날짜 문자열로 키를 생성한다.")
+        @Test
+        void buildCorrectKeyWithDateString() {
+            // arrange
+            String date = "20250911";
+
+            // act
+            String result = rankingService.buildRankingKey(date);
+
+            // assert
+            assertThat(result).isEqualTo(RANKING_PRODUCT_CACHE_KEY_PREFIX + "20250911");
+        }
+
+        @DisplayName("잘못된 날짜 문자열이라면 400 Bad Request 예외가 발생한다.")
+        @Test
+        void buildKeyWithEmptyString() {
+            // arrange
+            String date = "12345678";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> rankingService.buildRankingKey(date));
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-collector/src/test/java/com/loopers/domain/metrics/ProductRankingCacheServiceIntegrationTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/domain/metrics/ProductRankingCacheServiceIntegrationTest.java
@@ -32,8 +32,8 @@ class ProductRankingCacheServiceIntegrationTest {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(RANKING_DATE_PATTERN);
 
-    @BeforeEach
-    void setUp() {
+    @AfterEach
+    void tearDown() {
         redisCleanUp.truncateAll();
     }
 


### PR DESCRIPTION
## 📌 Summary
- Redis ZSET 기반 TopN 랭킹 조회 및 페이징 처리 로직 추가
- `ProductService.getListByIds`, `BrandService.getListByIds` 메서드 추가
- 단위/통합 테스트 구현